### PR TITLE
Add verification dimension, tighten audit thresholds (0.3.9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,14 @@ Tier 3: LSP/SCIP (on-demand, optional, >95%)
 
 Every ERROR has `fix_hint`. Every violation has `confidence` (0.0-1.0) and `resolution_tier`.
 
+## Build
+
+```bash
+cargo build --workspace                                    # Full build
+cargo clippy --workspace --all-targets -- -D warnings      # Lint (must pass clean)
+cargo fmt --check                                          # Format check
+```
+
 ## Testing
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "keel-cli"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "keel-core"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "petgraph",
  "rusqlite",
@@ -1246,18 +1246,19 @@ dependencies = [
 
 [[package]]
 name = "keel-enforce"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "keel-core",
  "keel-parsers",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "walkdir",
 ]
 
 [[package]]
 name = "keel-output"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "keel-core",
  "keel-enforce",
@@ -1267,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "keel-parsers"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "globset",
  "ignore",
@@ -1296,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "keel-server"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "axum",
  "keel-core",
@@ -1314,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "keel-tests"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "axum",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 license-file = "LICENSE"
 rust-version = "1.75"

--- a/crates/keel-cli/src/commands/audit.rs
+++ b/crates/keel-cli/src/commands/audit.rs
@@ -17,7 +17,13 @@ pub fn run(
         }
     };
 
-    const VALID_DIMENSIONS: &[&str] = &["structure", "discoverability", "navigation", "config"];
+    const VALID_DIMENSIONS: &[&str] = &[
+        "structure",
+        "discoverability",
+        "navigation",
+        "config",
+        "verification",
+    ];
     if let Some(ref dim) = dimension {
         if !VALID_DIMENSIONS.iter().any(|v| v.eq_ignore_ascii_case(dim)) {
             eprintln!(

--- a/crates/keel-enforce/Cargo.toml
+++ b/crates/keel-enforce/Cargo.toml
@@ -15,3 +15,4 @@ keel-parsers = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+walkdir = { workspace = true }

--- a/crates/keel-enforce/src/audit/agent_config.rs
+++ b/crates/keel-enforce/src/audit/agent_config.rs
@@ -40,23 +40,81 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
         let path = root_dir.join(instruction_file);
         if let Ok(content) = std::fs::read_to_string(&path) {
             let line_count = content.lines().count();
-            if line_count > 500 {
+            if line_count > 300 {
                 findings.push(AuditFinding {
                     severity: AuditSeverity::Fail,
                     check: "agent_instructions_size".into(),
-                    message: format!("{} is {} lines (>500)", instruction_file, line_count),
+                    message: format!("{} is {} lines (>300)", instruction_file, line_count),
                     tip: Some(
-                        "Split into focused sections or decompose into a config directory".into(),
+                        "This file is too large for agents to hold in context. \
+                         Split into focused sections under 150 lines each, or decompose \
+                         into a config directory (e.g., .claude/rules/)."
+                            .into(),
                     ),
                     file: Some(instruction_file.to_string()),
                     count: None,
                 });
-            } else if line_count > 300 {
+            } else if line_count > 150 {
                 findings.push(AuditFinding {
                     severity: AuditSeverity::Warn,
                     check: "agent_instructions_size".into(),
-                    message: format!("{} is {} lines (>300)", instruction_file, line_count),
-                    tip: Some("Consider splitting to keep agent context lean".into()),
+                    message: format!("{} is {} lines (>150)", instruction_file, line_count),
+                    tip: Some(format!(
+                        "Run `wc -l {}` and identify sections to extract into \
+                         separate files. Keep agent instructions under 150 lines \
+                         for optimal context usage.",
+                        instruction_file,
+                    )),
+                    file: Some(instruction_file.to_string()),
+                    count: None,
+                });
+            }
+
+            // Content quality: check for test command
+            let lower = content.to_lowercase();
+            let has_test_cmd = ["cargo test", "pytest", "npm test", "go test", "make test"]
+                .iter()
+                .any(|pat| lower.contains(pat));
+            if !has_test_cmd {
+                findings.push(AuditFinding {
+                    severity: AuditSeverity::Warn,
+                    check: "agent_instructions_no_test_cmd".into(),
+                    message: format!("{} has no test command", instruction_file),
+                    tip: Some(format!(
+                        "Add a ## Testing section to {} with runnable test commands, e.g.:\n  \
+                         cargo test\n\
+                         Agents need exact commands to verify their work.",
+                        instruction_file,
+                    )),
+                    file: Some(instruction_file.to_string()),
+                    count: None,
+                });
+            }
+
+            // Content quality: check for build/lint command
+            let has_build_cmd = [
+                "cargo build",
+                "cargo check",
+                "cargo clippy",
+                "npm run",
+                "go build",
+                "make",
+                "ruff",
+                "eslint",
+            ]
+            .iter()
+            .any(|pat| lower.contains(pat));
+            if !has_build_cmd {
+                findings.push(AuditFinding {
+                    severity: AuditSeverity::Warn,
+                    check: "agent_instructions_no_build_cmd".into(),
+                    message: format!("{} has no build/lint command", instruction_file),
+                    tip: Some(format!(
+                        "Add a ## Build section to {} with build/lint commands, e.g.:\n  \
+                         cargo clippy --workspace\n\
+                         Agents need to know how to check their changes compile.",
+                        instruction_file,
+                    )),
                     file: Some(instruction_file.to_string()),
                     count: None,
                 });
@@ -80,11 +138,13 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
 
     if found_config_dir.is_none() {
         findings.push(AuditFinding {
-            severity: AuditSeverity::Tip,
+            severity: AuditSeverity::Warn,
             check: "no_agent_dir".into(),
             message: "No agent config directory found".into(),
             tip: Some(
-                "Create .claude/, .cursor/, or similar for settings, hooks, and commands".into(),
+                "Create .claude/ or .cursor/ for settings, hooks, and commands. \
+                 Example: mkdir -p .claude/commands && echo '{}' > .claude/settings.json"
+                    .into(),
             ),
             file: None,
             count: None,
@@ -99,18 +159,44 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
         if settings_path.exists() {
             if let Ok(content) = std::fs::read_to_string(&settings_path) {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
-                    let has_hooks = parsed.get("hooks").is_some();
-                    if !has_hooks {
+                    let hooks = parsed.get("hooks");
+                    if hooks.is_none() {
                         findings.push(AuditFinding {
                             severity: AuditSeverity::Warn,
                             check: "no_hooks".into(),
                             message: "No hooks configured in .claude/settings.json".into(),
                             tip: Some(
-                                "Add PostToolUse hooks for automatic lint/compile feedback".into(),
+                                "Add PostToolUse hooks for automatic verification after edits. \
+                                 Example in .claude/settings.json:\n  \
+                                 \"hooks\": {\"PostToolUse\": [{\"matcher\": \"Edit|Write\", \
+                                 \"command\": \"keel compile --changed\"}]}"
+                                    .into(),
                             ),
                             file: Some(".claude/settings.json".into()),
                             count: None,
                         });
+                    } else if let Some(hooks_obj) = hooks.and_then(|h| h.as_object()) {
+                        // Hooks exist but check for PostToolUse-like entries
+                        let has_post_tool = hooks_obj.keys().any(|k| {
+                            let lower = k.to_lowercase();
+                            lower.contains("posttool") || lower.contains("post_tool")
+                        });
+                        if !has_post_tool {
+                            findings.push(AuditFinding {
+                                severity: AuditSeverity::Warn,
+                                check: "no_post_tool_hooks".into(),
+                                message: "Hooks exist but no PostToolUse hook found".into(),
+                                tip: Some(
+                                    "Add a hook that auto-runs verification after edits. \
+                                     Example in .claude/settings.json:\n  \
+                                     \"hooks\": {\"PostToolUse\": [{\"matcher\": \"Edit|Write\", \
+                                     \"command\": \"keel compile --changed\"}]}"
+                                        .into(),
+                                ),
+                                file: Some(".claude/settings.json".into()),
+                                count: None,
+                            });
+                        }
                     }
                 }
             }
@@ -120,7 +206,10 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
                 check: "no_hooks".into(),
                 message: "No .claude/settings.json found".into(),
                 tip: Some(
-                    "Create .claude/settings.json with hooks for automatic feedback loops".into(),
+                    "Create .claude/settings.json with hooks for automatic feedback loops. \
+                     Example:\n  {\"hooks\": {\"PostToolUse\": [{\"matcher\": \"Edit|Write\", \
+                     \"command\": \"keel compile --changed\"}]}}"
+                        .into(),
                 ),
                 file: None,
                 count: None,
@@ -131,10 +220,15 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
         let commands_dir = claude_dir.join("commands");
         if !commands_dir.exists() {
             findings.push(AuditFinding {
-                severity: AuditSeverity::Tip,
+                severity: AuditSeverity::Warn,
                 check: "no_commands".into(),
                 message: "No .claude/commands/ directory".into(),
-                tip: Some("Add slash commands for common workflows (e.g., /review, /test)".into()),
+                tip: Some(
+                    "Create .claude/commands/ with slash commands for common workflows. \
+                     Example: mkdir -p .claude/commands && echo 'Run cargo test' > \
+                     .claude/commands/test.md"
+                        .into(),
+                ),
                 file: None,
                 count: None,
             });

--- a/crates/keel-enforce/src/audit/discoverability.rs
+++ b/crates/keel-enforce/src/audit/discoverability.rs
@@ -92,14 +92,19 @@ pub fn check_discoverability(
 
         // Generic module name
         if is_generic_module(path) {
+            let stem = std::path::Path::new(path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("module");
             findings.push(AuditFinding {
                 severity: AuditSeverity::Warn,
                 check: "generic_module".into(),
                 message: format!("{} — generic module name", path),
-                tip: Some(
-                    "Rename to describe responsibility (e.g., string_utils.py, date_helpers.py)"
-                        .into(),
-                ),
+                tip: Some(format!(
+                    "Rename {} to describe its responsibility. Run `keel discover {}` \
+                     to see what it contains, then pick a name like {}_<responsibility>.",
+                    path, path, stem,
+                )),
                 file: Some(path.clone()),
                 count: None,
             });
@@ -123,7 +128,11 @@ pub fn check_discoverability(
                     severity: AuditSeverity::Warn,
                     check: "cryptic_name".into(),
                     message: format!("`{}` in {} — name too short (<3 chars)", node.name, path),
-                    tip: Some("Use descriptive names for agent comprehension".into()),
+                    tip: Some(format!(
+                        "Rename `{}` to a descriptive name (minimum 3 characters). \
+                         Spell out abbreviations for agent comprehension.",
+                        node.name,
+                    )),
                     file: Some(path.clone()),
                     count: None,
                 });
@@ -150,7 +159,27 @@ pub fn check_discoverability(
         // Public API surface ratio
         if total_count > 5 && public_count > 0 {
             let ratio = public_count as f64 / total_count as f64;
-            if ratio > 0.8 {
+            if ratio > 0.9 {
+                findings.push(AuditFinding {
+                    severity: AuditSeverity::Fail,
+                    check: "public_ratio".into(),
+                    message: format!(
+                        "{} — {:.0}% public ({}/{})",
+                        path,
+                        ratio * 100.0,
+                        public_count,
+                        total_count,
+                    ),
+                    tip: Some(format!(
+                        "Nearly all symbols in {} are public. Run `keel discover {}` to find \
+                         functions with 0 external callers, then remove `pub` from file-internal \
+                         helpers.",
+                        path, path,
+                    )),
+                    file: Some(path.clone()),
+                    count: None,
+                });
+            } else if ratio > 0.6 {
                 findings.push(AuditFinding {
                     severity: AuditSeverity::Warn,
                     check: "public_ratio".into(),
@@ -161,7 +190,11 @@ pub fn check_discoverability(
                         public_count,
                         total_count,
                     ),
-                    tip: Some("Consider marking internal helpers as private".into()),
+                    tip: Some(format!(
+                        "Run `keel discover {}` to identify functions with 0 external callers, \
+                         then restrict visibility with `pub(crate)` or by removing `pub`.",
+                        path,
+                    )),
                     file: Some(path.clone()),
                     count: None,
                 });
@@ -172,33 +205,68 @@ pub fn check_discoverability(
     // Aggregate findings
     if !missing_headers.is_empty() {
         let count = missing_headers.len() as u32;
-        let example = missing_headers.first().cloned().unwrap_or_default();
-        let prefix = comment_prefix(&example).unwrap_or("#");
+        let first_3: Vec<_> = missing_headers.iter().take(3).cloned().collect();
         findings.push(AuditFinding {
             severity: AuditSeverity::Warn,
             check: "missing_file_header".into(),
             message: format!("{} source files missing header comments", count),
             tip: Some(format!(
-                "Add a header block to each file:\n  {} purpose: <what this file does>\n  {} why: <why it exists>\n  {} related: <related files>",
-                prefix, prefix, prefix,
+                "Add a module-level header. For Rust: //! Purpose: <what this module does>. \
+                 For Python: \"\"\"<description>.\"\"\" at top. Example files missing: {}",
+                first_3.join(", "),
             )),
             file: None,
             count: Some(count),
         });
     }
 
-    if missing_type_hints > 0 {
+    if missing_type_hints > 10 {
+        findings.push(AuditFinding {
+            severity: AuditSeverity::Fail,
+            check: "missing_type_hints".into(),
+            message: format!("{} public functions missing type hints", missing_type_hints),
+            tip: Some(
+                "Add type annotations to all public function parameters and return types. \
+                 For Python: `def f(x: int) -> str`. For JS: add JSDoc @param/@returns. \
+                 Run `keel compile --changed` after fixing."
+                    .into(),
+            ),
+            file: None,
+            count: Some(missing_type_hints),
+        });
+    } else if missing_type_hints > 0 {
         findings.push(AuditFinding {
             severity: AuditSeverity::Warn,
             check: "missing_type_hints".into(),
             message: format!("{} public functions missing type hints", missing_type_hints),
-            tip: Some("Add type annotations to improve agent comprehension".into()),
+            tip: Some(
+                "Add type annotations to all public function parameters and return types. \
+                 For Python: `def f(x: int) -> str`. For JS: add JSDoc @param/@returns. \
+                 Run `keel compile --changed` after fixing."
+                    .into(),
+            ),
             file: None,
             count: Some(missing_type_hints),
         });
     }
 
-    if missing_docstrings > 0 {
+    if missing_docstrings > 5 {
+        findings.push(AuditFinding {
+            severity: AuditSeverity::Fail,
+            check: "missing_docstrings".into(),
+            message: format!(
+                "{} high-use public functions missing docstrings (>3 callers)",
+                missing_docstrings,
+            ),
+            tip: Some(
+                "Add docstrings to these high-use public functions describing: purpose, \
+                 parameters, return value, and side effects. Run `keel compile` to verify."
+                    .into(),
+            ),
+            file: None,
+            count: Some(missing_docstrings),
+        });
+    } else if missing_docstrings > 0 {
         findings.push(AuditFinding {
             severity: AuditSeverity::Warn,
             check: "missing_docstrings".into(),
@@ -206,7 +274,11 @@ pub fn check_discoverability(
                 "{} high-use public functions missing docstrings (>3 callers)",
                 missing_docstrings,
             ),
-            tip: Some("Add docstrings to frequently-called public functions".into()),
+            tip: Some(
+                "Add docstrings to these high-use public functions describing: purpose, \
+                 parameters, return value, and side effects. Run `keel compile` to verify."
+                    .into(),
+            ),
             file: None,
             count: Some(missing_docstrings),
         });

--- a/crates/keel-enforce/src/audit/mod.rs
+++ b/crates/keel-enforce/src/audit/mod.rs
@@ -1,12 +1,13 @@
 //! Audit module — AI-readiness scorecard for codebases.
 //!
-//! Scores a codebase across 4 dimensions: Structure, Discoverability,
-//! Navigation, and Agent Config. Each dimension scored 0–5 (max total: 20).
+//! Scores a codebase across 5 dimensions: Structure, Discoverability,
+//! Navigation, Agent Config, and Verification. Each dimension scored 0–5 (max total: 25).
 
 pub mod agent_config;
 pub mod discoverability;
 pub mod navigation;
 pub mod structure;
+pub mod verification;
 
 use keel_core::store::GraphStore;
 
@@ -68,6 +69,17 @@ pub fn audit_repo(
         let score = compute_dimension_score(&findings);
         dimensions.push(AuditDimension {
             name: "config".into(),
+            score,
+            max_score: 5,
+            findings,
+        });
+    }
+
+    if run_dim("verification") {
+        let findings = verification::check_verification(root_dir);
+        let score = compute_dimension_score(&findings);
+        dimensions.push(AuditDimension {
+            name: "verification".into(),
             score,
             max_score: 5,
             findings,

--- a/crates/keel-enforce/src/audit/navigation.rs
+++ b/crates/keel-enforce/src/audit/navigation.rs
@@ -54,24 +54,37 @@ pub fn check_navigation(store: &dyn GraphStore, files: Option<&[String]>) -> Vec
     let cycles = find_cycles(&module_deps);
     for cycle in &cycles {
         let chain = cycle.join(" → ");
+        let first = cycle.first().cloned().unwrap_or_default();
+        let second = cycle.get(1).cloned().unwrap_or_default();
         findings.push(AuditFinding {
-            severity: AuditSeverity::Warn,
+            severity: AuditSeverity::Fail,
             check: "circular_dep".into(),
             message: format!("Circular dependency: {}", chain),
-            tip: Some("Extract shared types to a common module to break the cycle".into()),
+            tip: Some(format!(
+                "Circular dependency: {}. Extract the shared types/functions into a new module \
+                 that both sides can import. Run `keel discover {}` and `keel discover {}` \
+                 to identify the shared symbols.",
+                chain, first, second,
+            )),
             file: None,
             count: None,
         });
     }
 
-    // High cross-module coupling: module imports >10 others
+    // High cross-module coupling: module imports >7 others
     for (path, deps) in &module_deps {
-        if deps.len() > 10 {
+        if deps.len() > 7 {
             findings.push(AuditFinding {
                 severity: AuditSeverity::Warn,
                 check: "high_coupling".into(),
-                message: format!("{} imports {} other modules (>10)", path, deps.len()),
-                tip: Some("Reduce coupling by introducing facade modules or interfaces".into()),
+                message: format!("{} imports {} other modules (>7)", path, deps.len()),
+                tip: Some(format!(
+                    "This module imports {} others (>7). Run `keel analyze {}` to see the \
+                     dependency breakdown, then introduce a facade module or re-exports \
+                     to reduce direct imports.",
+                    deps.len(),
+                    path,
+                )),
                 file: Some(path.clone()),
                 count: None,
             });
@@ -128,10 +141,11 @@ pub fn check_navigation(store: &dyn GraphStore, files: Option<&[String]>) -> Vec
                         "`{}` in {} — public, {} callers, no docstring",
                         node.name, module.file_path, call_callers,
                     ),
-                    tip: Some(
-                        "High-use public functions need docstrings to prevent misuse by agents"
-                            .into(),
-                    ),
+                    tip: Some(format!(
+                        "Add a docstring to `{}` — it has {} callers and no documentation. \
+                         Include: purpose, parameters, return type, and error conditions.",
+                        node.name, call_callers,
+                    )),
                     file: Some(module.file_path.clone()),
                     count: None,
                 });
@@ -140,18 +154,20 @@ pub fn check_navigation(store: &dyn GraphStore, files: Option<&[String]>) -> Vec
             // Deep call chain detection (BFS from functions with 0 incoming calls)
             if node.kind == NodeKind::Function && call_callers == 0 {
                 let max_depth = bfs_max_depth(store, node.id);
-                if max_depth > 7 {
+                if max_depth > 5 {
                     findings.push(AuditFinding {
                         severity: AuditSeverity::Warn,
                         check: "deep_call_chain".into(),
                         message: format!(
-                            "`{}` in {} — call chain depth {} (>7 hops)",
+                            "`{}` in {} — call chain depth {} (>5 hops)",
                             node.name, module.file_path, max_depth,
                         ),
-                        tip: Some(
-                            "Deep call chains make it hard for agents to trace execution flow"
-                                .into(),
-                        ),
+                        tip: Some(format!(
+                            "Call chain from `{}` is {} hops deep (>5). Agents lose context \
+                             beyond 5 levels. Run `keel discover --name {}` to trace the chain, \
+                             then flatten with intermediate orchestrator functions.",
+                            node.name, max_depth, node.name,
+                        )),
                         file: Some(module.file_path.clone()),
                         count: None,
                     });
@@ -164,13 +180,18 @@ pub fn check_navigation(store: &dyn GraphStore, files: Option<&[String]>) -> Vec
             let non_module = nodes.iter().any(|n| n.kind != NodeKind::Module);
             if non_module {
                 findings.push(AuditFinding {
-                    severity: AuditSeverity::Tip,
+                    severity: AuditSeverity::Warn,
                     check: "orphan_file".into(),
                     message: format!(
                         "{} — no external dependencies in either direction",
                         module.file_path,
                     ),
-                    tip: Some("Orphan files may be dead code or poorly integrated".into()),
+                    tip: Some(format!(
+                        "This file has no connections to the codebase. Run `keel discover {}` \
+                         to verify — if it shows no symbols, it may be dead code. Either \
+                         integrate it or delete it.",
+                        module.file_path,
+                    )),
                     file: Some(module.file_path.clone()),
                     count: None,
                 });

--- a/crates/keel-enforce/src/audit/structure.rs
+++ b/crates/keel-enforce/src/audit/structure.rs
@@ -33,7 +33,12 @@ pub fn check_structure(store: &dyn GraphStore, files: Option<&[String]>) -> Vec<
                 severity: AuditSeverity::Fail,
                 check: "file_size".into(),
                 message: format!("{} — {} lines (>800)", module.file_path, line_count),
-                tip: Some("Split into focused modules under 400 lines".into()),
+                tip: Some(format!(
+                    "This file is too large for agents to reason about. Run \
+                     `keel analyze {}` to identify natural split points, then extract \
+                     cohesive groups into separate modules under 400 lines.",
+                    module.file_path,
+                )),
                 file: Some(module.file_path.clone()),
                 count: None,
             });
@@ -42,20 +47,45 @@ pub fn check_structure(store: &dyn GraphStore, files: Option<&[String]>) -> Vec<
                 severity: AuditSeverity::Warn,
                 check: "file_size".into(),
                 message: format!("{} — {} lines (>400)", module.file_path, line_count),
-                tip: Some("Consider splitting into smaller modules".into()),
+                tip: Some(format!(
+                    "Run `keel analyze {}` to see function groupings and identify split \
+                     points before this file grows past 800 lines.",
+                    module.file_path,
+                )),
                 file: Some(module.file_path.clone()),
                 count: None,
             });
         }
 
-        // God file: >20 symbols
+        // God file: >20 symbols, FAIL at >35
         let symbol_count = nodes.iter().filter(|n| n.kind != NodeKind::Module).count();
-        if symbol_count > 20 {
+        if symbol_count > 35 {
+            findings.push(AuditFinding {
+                severity: AuditSeverity::Fail,
+                check: "god_file".into(),
+                message: format!("{} — {} symbols (>35)", module.file_path, symbol_count),
+                tip: Some(format!(
+                    "Run `keel discover {}` to list all {} symbols. Group related \
+                     functions and extract each group into a new module of <20 symbols.",
+                    module.file_path, symbol_count,
+                )),
+                file: Some(module.file_path.clone()),
+                count: None,
+            });
+        } else if symbol_count > 20 {
+            let stem = std::path::Path::new(&module.file_path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("module");
             findings.push(AuditFinding {
                 severity: AuditSeverity::Warn,
                 check: "god_file".into(),
                 message: format!("{} — {} symbols (>20)", module.file_path, symbol_count),
-                tip: Some("Split by responsibility into focused modules".into()),
+                tip: Some(format!(
+                    "Run `keel discover {}` to see symbol groupings. Extract related \
+                     functions into a new module (e.g., {}_ops.rs or {}_helpers.rs).",
+                    module.file_path, stem, stem,
+                )),
                 file: Some(module.file_path.clone()),
                 count: None,
             });
@@ -76,7 +106,11 @@ pub fn check_structure(store: &dyn GraphStore, files: Option<&[String]>) -> Vec<
                         "`{}` in {} — {} lines (>200)",
                         node.name, module.file_path, fn_lines
                     ),
-                    tip: Some("Extract sub-operations into helper functions".into()),
+                    tip: Some(format!(
+                        "Extract sub-operations from `{}`. Run `keel discover {}` to see \
+                         what it calls and group related operations into helper functions.",
+                        node.name, module.file_path,
+                    )),
                     file: Some(module.file_path.clone()),
                     count: None,
                 });
@@ -88,7 +122,11 @@ pub fn check_structure(store: &dyn GraphStore, files: Option<&[String]>) -> Vec<
                         "`{}` in {} — {} lines (>100)",
                         node.name, module.file_path, fn_lines
                     ),
-                    tip: Some("Consider breaking into smaller functions".into()),
+                    tip: Some(format!(
+                        "Run `keel check {}` to assess refactoring impact, then extract \
+                         sub-operations from `{}` into focused helpers.",
+                        node.hash, node.name,
+                    )),
                     file: Some(module.file_path.clone()),
                     count: None,
                 });
@@ -108,10 +146,12 @@ pub fn check_structure(store: &dyn GraphStore, files: Option<&[String]>) -> Vec<
                         "`{}` in {} — {} lines, {} callees",
                         node.name, module.file_path, fn_lines, callees
                     ),
-                    tip: Some(
-                        "Monolithic function: extract sub-operations or split responsibilities"
-                            .into(),
-                    ),
+                    tip: Some(format!(
+                        "Function `{}` is both long and deeply connected ({} callees). \
+                         Run `keel discover --name {}` to see its call graph, then \
+                         extract sub-operations.",
+                        node.name, callees, node.name,
+                    )),
                     file: Some(module.file_path.clone()),
                     count: None,
                 });

--- a/crates/keel-enforce/src/audit/verification.rs
+++ b/crates/keel-enforce/src/audit/verification.rs
@@ -1,0 +1,235 @@
+//! Verification dimension — tests, CI, test coverage, test command documentation.
+
+use std::path::Path;
+
+use crate::types::{AuditFinding, AuditSeverity};
+
+/// File patterns that indicate test files exist.
+const TEST_DIR_NAMES: &[&str] = &["tests", "__tests__", "test"];
+
+/// File glob patterns for test files (checked via simple suffix/prefix matching).
+const TEST_FILE_PATTERNS: &[(&str, &str)] = &[
+    ("test_", ".py"),  // Python: test_*.py
+    ("", "_test.go"),  // Go: *_test.go
+    ("", "_test.rs"),  // Rust: *_test.rs
+    ("", ".test.ts"),  // TS: *.test.ts
+    ("", ".test.tsx"), // TSX: *.test.tsx
+    ("", ".test.js"),  // JS: *.test.js
+    ("", ".test.jsx"), // JSX: *.test.jsx
+    ("", ".spec.ts"),  // TS: *.spec.ts
+    ("", ".spec.tsx"), // TSX: *.spec.tsx
+    ("", ".spec.js"),  // JS: *.spec.js
+    ("", ".spec.jsx"), // JSX: *.spec.jsx
+];
+
+/// Source file extensions to count.
+const SOURCE_EXTENSIONS: &[&str] = &["py", "rs", "ts", "tsx", "js", "jsx", "go"];
+
+/// CI config paths to check.
+const CI_CONFIGS: &[&str] = &[
+    ".github/workflows",
+    ".gitlab-ci.yml",
+    "Jenkinsfile",
+    ".circleci",
+    "bitbucket-pipelines.yml",
+];
+
+/// Test command patterns to search for in instruction files.
+const TEST_CMD_PATTERNS: &[&str] = &[
+    "cargo test",
+    "pytest",
+    "npm test",
+    "go test",
+    "make test",
+    "yarn test",
+    "npx jest",
+    "npx vitest",
+];
+
+/// Agent instruction files to search for test commands.
+const INSTRUCTION_FILES: &[&str] = &[
+    "CLAUDE.md",
+    ".cursorrules",
+    "GEMINI.md",
+    "WINDSURF.md",
+    "AGENTS.md",
+    "COPILOT.md",
+    "README.md",
+];
+
+pub fn check_verification(root_dir: &Path) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+
+    let (test_file_count, source_file_count) = count_test_and_source_files(root_dir);
+    let has_test_dir = TEST_DIR_NAMES.iter().any(|d| root_dir.join(d).is_dir());
+    let has_tests = has_test_dir || test_file_count > 0;
+
+    // Check 1: has_tests
+    if !has_tests {
+        findings.push(AuditFinding {
+            severity: AuditSeverity::Fail,
+            check: "has_tests".into(),
+            message: "No test files found".into(),
+            tip: Some(
+                "Create a tests/ directory with at least one test. For Rust: add \
+                 #[cfg(test)] mod tests in src/ or create tests/. For Python: create \
+                 tests/test_<module>.py. Then verify with your test runner."
+                    .into(),
+            ),
+            file: None,
+            count: None,
+        });
+    }
+
+    // Check 2: test_command_documented
+    let test_cmd_documented = INSTRUCTION_FILES.iter().any(|f| {
+        let path = root_dir.join(f);
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            let lower = content.to_lowercase();
+            TEST_CMD_PATTERNS.iter().any(|pat| lower.contains(pat))
+        } else {
+            false
+        }
+    });
+
+    if !test_cmd_documented {
+        findings.push(AuditFinding {
+            severity: AuditSeverity::Warn,
+            check: "test_command_documented".into(),
+            message: "No test command found in agent instruction files or README".into(),
+            tip: Some(
+                "Add a ## Testing section to CLAUDE.md with the exact command:\n  \
+                 ```bash\n  cargo test\n  ```\n\
+                 Agents need to know how to verify their changes."
+                    .into(),
+            ),
+            file: None,
+            count: None,
+        });
+    }
+
+    // Check 3: test_coverage_ratio
+    if has_tests && source_file_count > 0 {
+        let ratio = test_file_count as f64 / source_file_count as f64;
+        if ratio < 0.1 {
+            findings.push(AuditFinding {
+                severity: AuditSeverity::Warn,
+                check: "test_coverage_ratio".into(),
+                message: format!(
+                    "Low test coverage: {} test files for {} source files ({:.0}%)",
+                    test_file_count,
+                    source_file_count,
+                    ratio * 100.0,
+                ),
+                tip: Some(format!(
+                    "Low test coverage: {} test files for {} source files. Run \
+                     `keel map --llm` to identify high-caller functions — these are \
+                     the highest-value targets for new tests.",
+                    test_file_count, source_file_count,
+                )),
+                file: None,
+                count: Some(test_file_count as u32),
+            });
+        }
+    }
+
+    // Check 4: has_ci_config
+    let has_ci = CI_CONFIGS.iter().any(|c| root_dir.join(c).exists());
+    if !has_ci {
+        findings.push(AuditFinding {
+            severity: AuditSeverity::Warn,
+            check: "has_ci_config".into(),
+            message: "No CI configuration found".into(),
+            tip: Some(
+                "Add CI configuration to run tests on every push. Create \
+                 .github/workflows/ci.yml with steps for checkout, build, and test."
+                    .into(),
+            ),
+            file: None,
+            count: None,
+        });
+    }
+
+    findings
+}
+
+/// Count test files and source files by walking the directory tree.
+fn count_test_and_source_files(root_dir: &Path) -> (usize, usize) {
+    let mut test_count = 0usize;
+    let mut source_count = 0usize;
+
+    let walker = walkdir::WalkDir::new(root_dir)
+        .max_depth(6)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_str().unwrap_or("");
+            // Skip hidden dirs (except .github), node_modules, target, vendor
+            if e.file_type().is_dir() {
+                return !matches!(
+                    name,
+                    "node_modules" | "target" | "vendor" | ".git" | "dist" | "build"
+                );
+            }
+            true
+        });
+
+    for entry in walker.flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_str().unwrap_or("");
+        let path_str = entry.path().to_str().unwrap_or("");
+        let is_test = is_test_file(name) || is_in_test_dir(path_str);
+        let is_source = SOURCE_EXTENSIONS
+            .iter()
+            .any(|ext| name.ends_with(&format!(".{}", ext)));
+
+        // For Rust files, also check for inline #[cfg(test)] modules
+        if !is_test && name.ends_with(".rs") {
+            if let Ok(content) = std::fs::read_to_string(entry.path()) {
+                if content.contains("#[cfg(test)]") {
+                    test_count += 1;
+                    // Still count as source too (it's both)
+                    source_count += 1;
+                    continue;
+                }
+            }
+        }
+
+        if is_test {
+            test_count += 1;
+        } else if is_source {
+            source_count += 1;
+        }
+    }
+
+    (test_count, source_count)
+}
+
+/// Check if a file is inside a test directory (tests/, __tests__/, etc.).
+fn is_in_test_dir(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.contains("/tests/")
+        || normalized.contains("/__tests__/")
+        || normalized.contains("/test/")
+}
+
+/// Check if a filename matches test file patterns.
+fn is_test_file(name: &str) -> bool {
+    // Rust inline tests (#[cfg(test)]) won't show as separate files,
+    // but *_test.rs files in tests/ will.
+    for (prefix, suffix) in TEST_FILE_PATTERNS {
+        if !prefix.is_empty() && !suffix.is_empty() {
+            if name.starts_with(prefix) && name.ends_with(suffix) {
+                return true;
+            }
+        } else if !prefix.is_empty() {
+            if name.starts_with(prefix) {
+                return true;
+            }
+        } else if !suffix.is_empty() && name.ends_with(suffix) {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/keel-output/src/radar.rs
+++ b/crates/keel-output/src/radar.rs
@@ -48,6 +48,7 @@ fn dim_label(name: &str) -> &str {
         "discoverability" => "Discoverability",
         "navigation" => "Navigation",
         "config" => "Agent Config",
+        "verification" => "Verification",
         _ => name,
     }
 }


### PR DESCRIPTION
## Summary
- **New 5th audit dimension: Verification** — checks for tests, test commands, coverage ratio, and CI config. Detects Rust inline `#[cfg(test)]` modules, test file naming patterns, and `tests/` directories
- **Tightened thresholds across all dimensions** — circular deps now FAIL (was WARN), coupling >7 (was >10), call chain >5 (was >7), instruction files FAIL >300 (was >500), `god_file` FAIL at >35 symbols, `public_ratio` FAIL at >90%
- **All tips rewritten to be LLM-actionable** — every tip now contains concrete `keel` commands, shell commands, or copy-pasteable examples instead of vague suggestions
- **Keel self-score: 23/25 A** (was 19/20 A+ — max now 25)
- Added `## Build` section to CLAUDE.md (eating our own dogfood)

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 1,320 tests pass
- [x] `keel audit` — score 23/25 A
- [x] `keel audit --dimension verification` — works in isolation (5/5)
- [x] All tips contain actionable commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)