### PR TITLE
Skip E002/E003 in test files, harden audit checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
 name = "keel-enforce"
 version = "0.4.2"
 dependencies = [
+ "ignore",
  "keel-core",
  "keel-parsers",
  "serde",

--- a/crates/keel-enforce/Cargo.toml
+++ b/crates/keel-enforce/Cargo.toml
@@ -16,3 +16,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 walkdir = { workspace = true }
+ignore = { workspace = true }

--- a/crates/keel-enforce/src/audit/agent_config.rs
+++ b/crates/keel-enforce/src/audit/agent_config.rs
@@ -23,6 +23,7 @@ const AGENT_INSTRUCTION_DIRS: &[&str] = &[".cursor/rules"];
 /// Agent config directories.
 const AGENT_CONFIG_DIRS: &[&str] = &[".claude", ".cursor", ".gemini", ".windsurf", ".letta"];
 
+/// Audit agent configuration files (CLAUDE.md, .cursorrules, etc.) for completeness.
 pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
     let mut findings = Vec::new();
 
@@ -39,7 +40,21 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
         // Check size of whichever instruction file was found
         let path = root_dir.join(instruction_file);
         if let Ok(content) = std::fs::read_to_string(&path) {
-            let line_count = content.lines().count();
+            // Exclude keel-injected content between <!-- keel:start --> and <!-- keel:end -->
+            let line_count = content
+                .lines()
+                .scan(false, |in_keel_block, line| {
+                    if line.contains("<!-- keel:start") {
+                        *in_keel_block = true;
+                    }
+                    let skip = *in_keel_block;
+                    if line.contains("<!-- keel:end") {
+                        *in_keel_block = false;
+                    }
+                    Some(!skip)
+                })
+                .filter(|&keep| keep)
+                .count();
             if line_count > 300 {
                 findings.push(AuditFinding {
                     severity: AuditSeverity::Fail,
@@ -311,13 +326,26 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
             });
         }
 
-        // Check for slash commands
+        // Check for slash commands — directory must exist AND contain .md files
         let commands_dir = claude_dir.join("commands");
-        if !commands_dir.exists() {
+        let has_command_files = commands_dir.is_dir()
+            && std::fs::read_dir(&commands_dir)
+                .map(|entries| {
+                    entries
+                        .flatten()
+                        .any(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("md"))
+                })
+                .unwrap_or(false);
+        if !has_command_files {
+            let message = if commands_dir.is_dir() {
+                "No .md files in .claude/commands/"
+            } else {
+                "No .claude/commands/ directory"
+            };
             findings.push(AuditFinding {
                 severity: AuditSeverity::Warn,
                 check: "no_commands".into(),
-                message: "No .claude/commands/ directory".into(),
+                message: message.into(),
                 tip: Some(
                     "Create .claude/commands/ with slash commands for common workflows. \
                      Example: mkdir -p .claude/commands && echo 'Run cargo test' > \
@@ -333,7 +361,7 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
     // Check for progressive disclosure (folder-level rules)
     let has_folder_rules = root_dir.join(".claude/rules").is_dir()
         || root_dir.join(".cursor/rules").is_dir()
-        || has_subfolder_claude_md(root_dir);
+        || super::has_subfolder_claude_md(root_dir);
     if !has_folder_rules {
         findings.push(AuditFinding {
             severity: AuditSeverity::Tip,
@@ -351,35 +379,4 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
     }
 
     findings
-}
-
-fn has_subfolder_claude_md(root_dir: &Path) -> bool {
-    let entries = match std::fs::read_dir(root_dir) {
-        Ok(e) => e,
-        Err(_) => return false,
-    };
-    for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        let name = entry.file_name();
-        let name_str = name.to_str().unwrap_or("");
-        if name_str.starts_with('.') || name_str == "node_modules" || name_str == "target" {
-            continue;
-        }
-        if entry.path().join("CLAUDE.md").exists() {
-            return true;
-        }
-        // Check one more level
-        if let Ok(sub_entries) = std::fs::read_dir(entry.path()) {
-            for sub in sub_entries.flatten() {
-                if sub.file_type().map(|t| t.is_dir()).unwrap_or(false)
-                    && sub.path().join("CLAUDE.md").exists()
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    false
 }

--- a/crates/keel-enforce/src/audit/agent_config.rs
+++ b/crates/keel-enforce/src/audit/agent_config.rs
@@ -44,6 +44,8 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
             let line_count = content
                 .lines()
                 .scan(false, |in_keel_block, line| {
+                    // Order matters: set flag BEFORE reading it so the
+                    // start-tag line itself is excluded from the count.
                     if line.contains("<!-- keel:start") {
                         *in_keel_block = true;
                     }

--- a/crates/keel-enforce/src/audit/agent_config.rs
+++ b/crates/keel-enforce/src/audit/agent_config.rs
@@ -89,7 +89,7 @@ pub fn check_agent_config(root_dir: &Path) -> Vec<AuditFinding> {
 
             // Content quality: check for test command
             let lower = content.to_lowercase();
-            let has_test_cmd = ["cargo test", "pytest", "npm test", "go test", "make test"]
+            let has_test_cmd = super::verification::TEST_CMD_PATTERNS
                 .iter()
                 .any(|pat| lower.contains(pat));
             if !has_test_cmd {

--- a/crates/keel-enforce/src/audit/mod.rs
+++ b/crates/keel-enforce/src/audit/mod.rs
@@ -98,6 +98,38 @@ pub fn audit_repo(
     }
 }
 
+/// Check if any subfolder (up to 2 levels) contains a CLAUDE.md file.
+fn has_subfolder_claude_md(root_dir: &std::path::Path) -> bool {
+    let entries = match std::fs::read_dir(root_dir) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = name.to_str().unwrap_or("");
+        if name_str.starts_with('.') || name_str == "node_modules" || name_str == "target" {
+            continue;
+        }
+        if entry.path().join("CLAUDE.md").exists() {
+            return true;
+        }
+        // Check one more level
+        if let Ok(sub_entries) = std::fs::read_dir(entry.path()) {
+            for sub in sub_entries.flatten() {
+                if sub.file_type().map(|t| t.is_dir()).unwrap_or(false)
+                    && sub.path().join("CLAUDE.md").exists()
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Returns true if the audit result should cause a non-zero exit.
 pub fn should_fail(result: &AuditResult, options: &AuditOptions) -> bool {
     if options.strict {

--- a/crates/keel-enforce/src/audit/verification.rs
+++ b/crates/keel-enforce/src/audit/verification.rs
@@ -21,18 +21,16 @@ const CI_CONFIGS: &[&str] = &[
 ];
 
 /// Test command patterns to search for in instruction files.
-const TEST_CMD_PATTERNS: &[&str] = &[
+/// Also used by `agent_config` to check instruction file content quality.
+pub const TEST_CMD_PATTERNS: &[&str] = &[
     "cargo test",
-    "pytest",
-    "uv run pytest",
+    "pytest", // also matches "uv run pytest"
     "npm test",
     "go test",
     "make test",
     "yarn test",
-    "npx jest",
-    "npx vitest",
-    "vitest",
-    "jest",
+    "vitest", // also matches "npx vitest"
+    "jest",   // also matches "npx jest"
     "playwright",
     "bun test",
 ];
@@ -273,12 +271,14 @@ fn count_test_and_source_files(root_dir: &Path) -> (usize, usize) {
             .iter()
             .any(|ext| name.ends_with(&format!(".{}", ext)));
 
-        // For Rust files, also check for inline #[cfg(test)] modules
+        // For Rust files, also check for inline #[cfg(test)] modules.
+        // Intentionally counted as both test AND source: the file contains
+        // production code with co-located tests, so it contributes to both
+        // the test coverage numerator and the source denominator.
         if !is_test && name.ends_with(".rs") {
             if let Ok(content) = std::fs::read_to_string(entry.path()) {
                 if content.contains("#[cfg(test)]") {
                     test_count += 1;
-                    // Still count as source too (it's both)
                     source_count += 1;
                     continue;
                 }

--- a/crates/keel-enforce/src/audit/verification.rs
+++ b/crates/keel-enforce/src/audit/verification.rs
@@ -294,4 +294,3 @@ fn count_test_and_source_files(root_dir: &Path) -> (usize, usize) {
 
     (test_count, source_count)
 }
-

--- a/crates/keel-enforce/src/audit/verification.rs
+++ b/crates/keel-enforce/src/audit/verification.rs
@@ -3,24 +3,10 @@
 use std::path::Path;
 
 use crate::types::{AuditFinding, AuditSeverity};
+use crate::violations_util;
 
 /// File patterns that indicate test files exist.
 const TEST_DIR_NAMES: &[&str] = &["tests", "__tests__", "test"];
-
-/// File glob patterns for test files (checked via simple suffix/prefix matching).
-const TEST_FILE_PATTERNS: &[(&str, &str)] = &[
-    ("test_", ".py"),  // Python: test_*.py
-    ("", "_test.go"),  // Go: *_test.go
-    ("", "_test.rs"),  // Rust: *_test.rs
-    ("", ".test.ts"),  // TS: *.test.ts
-    ("", ".test.tsx"), // TSX: *.test.tsx
-    ("", ".test.js"),  // JS: *.test.js
-    ("", ".test.jsx"), // JSX: *.test.jsx
-    ("", ".spec.ts"),  // TS: *.spec.ts
-    ("", ".spec.tsx"), // TSX: *.spec.tsx
-    ("", ".spec.js"),  // JS: *.spec.js
-    ("", ".spec.jsx"), // JSX: *.spec.jsx
-];
 
 /// Source file extensions to count.
 const SOURCE_EXTENSIONS: &[&str] = &["py", "rs", "ts", "tsx", "js", "jsx", "go"];
@@ -39,7 +25,6 @@ const TEST_CMD_PATTERNS: &[&str] = &[
     "cargo test",
     "pytest",
     "uv run pytest",
-    "uv run test",
     "npm test",
     "go test",
     "make test",
@@ -283,7 +268,7 @@ fn count_test_and_source_files(root_dir: &Path) -> (usize, usize) {
         }
         let name = entry.file_name().to_str().unwrap_or("");
         let path_str = entry.path().to_str().unwrap_or("");
-        let is_test = is_test_file(name) || is_in_test_dir(path_str);
+        let is_test = violations_util::is_test_file(path_str);
         let is_source = SOURCE_EXTENSIONS
             .iter()
             .any(|ext| name.ends_with(&format!(".{}", ext)));
@@ -310,30 +295,3 @@ fn count_test_and_source_files(root_dir: &Path) -> (usize, usize) {
     (test_count, source_count)
 }
 
-/// Check if a file is inside a test directory (tests/, __tests__/, etc.).
-fn is_in_test_dir(path: &str) -> bool {
-    let normalized = path.replace('\\', "/");
-    normalized.contains("/tests/")
-        || normalized.contains("/__tests__/")
-        || normalized.contains("/test/")
-}
-
-/// Check if a filename matches test file patterns.
-fn is_test_file(name: &str) -> bool {
-    // Rust inline tests (#[cfg(test)]) won't show as separate files,
-    // but *_test.rs files in tests/ will.
-    for (prefix, suffix) in TEST_FILE_PATTERNS {
-        if !prefix.is_empty() && !suffix.is_empty() {
-            if name.starts_with(prefix) && name.ends_with(suffix) {
-                return true;
-            }
-        } else if !prefix.is_empty() {
-            if name.starts_with(prefix) {
-                return true;
-            }
-        } else if !suffix.is_empty() && name.ends_with(suffix) {
-            return true;
-        }
-    }
-    false
-}

--- a/crates/keel-enforce/src/audit/verification.rs
+++ b/crates/keel-enforce/src/audit/verification.rs
@@ -38,12 +38,18 @@ const CI_CONFIGS: &[&str] = &[
 const TEST_CMD_PATTERNS: &[&str] = &[
     "cargo test",
     "pytest",
+    "uv run pytest",
+    "uv run test",
     "npm test",
     "go test",
     "make test",
     "yarn test",
     "npx jest",
     "npx vitest",
+    "vitest",
+    "jest",
+    "playwright",
+    "bun test",
 ];
 
 /// Agent instruction files to search for test commands.
@@ -57,6 +63,7 @@ const INSTRUCTION_FILES: &[&str] = &[
     "README.md",
 ];
 
+/// Audit verification practices: test coverage, CI config, and pre-commit hooks.
 pub fn check_verification(root_dir: &Path) -> Vec<AuditFinding> {
     let mut findings = Vec::new();
 
@@ -98,8 +105,9 @@ pub fn check_verification(root_dir: &Path) -> Vec<AuditFinding> {
             check: "test_command_documented".into(),
             message: "No test command found in agent instruction files or README".into(),
             tip: Some(
-                "Add a ## Testing section to CLAUDE.md with the exact command:\n  \
-                 ```bash\n  cargo test\n  ```\n\
+                "Document the test command in an agent instruction file (CLAUDE.md, \
+                 .cursorrules, etc.):\n  \
+                 ```bash\n  cargo test  # or: pytest, npm test, go test, etc.\n  ```\n\
                  Agents need to know how to verify their changes."
                     .into(),
             ),
@@ -134,7 +142,23 @@ pub fn check_verification(root_dir: &Path) -> Vec<AuditFinding> {
     }
 
     // Check 4: has_ci_config
-    let has_ci = CI_CONFIGS.iter().any(|c| root_dir.join(c).exists());
+    // For directories (e.g. .github/workflows), verify they contain .yml/.yaml files.
+    // For files (e.g. .gitlab-ci.yml), just check existence.
+    let has_ci = CI_CONFIGS.iter().any(|c| {
+        let path = root_dir.join(c);
+        if path.is_dir() {
+            std::fs::read_dir(&path)
+                .map(|entries| {
+                    entries.flatten().any(|e| {
+                        let name = e.file_name().to_string_lossy().to_string();
+                        name.ends_with(".yml") || name.ends_with(".yaml")
+                    })
+                })
+                .unwrap_or(false)
+        } else {
+            path.exists()
+        }
+    });
     if !has_ci {
         findings.push(AuditFinding {
             severity: AuditSeverity::Warn,
@@ -240,27 +264,21 @@ pub fn check_verification(root_dir: &Path) -> Vec<AuditFinding> {
 }
 
 /// Count test files and source files by walking the directory tree.
+/// Uses `ignore::WalkBuilder` to respect .gitignore and .keelignore,
+/// preventing inflated counts from vendored/generated code.
 fn count_test_and_source_files(root_dir: &Path) -> (usize, usize) {
     let mut test_count = 0usize;
     let mut source_count = 0usize;
 
-    let walker = walkdir::WalkDir::new(root_dir)
-        .max_depth(6)
-        .into_iter()
-        .filter_entry(|e| {
-            let name = e.file_name().to_str().unwrap_or("");
-            // Skip hidden dirs (except .github), node_modules, target, vendor
-            if e.file_type().is_dir() {
-                return !matches!(
-                    name,
-                    "node_modules" | "target" | "vendor" | ".git" | "dist" | "build"
-                );
-            }
-            true
-        });
+    let walker = ignore::WalkBuilder::new(root_dir)
+        .hidden(true)
+        .git_ignore(true)
+        .add_custom_ignore_filename(".keelignore")
+        .max_depth(Some(6))
+        .build();
 
     for entry in walker.flatten() {
-        if !entry.file_type().is_file() {
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
             continue;
         }
         let name = entry.file_name().to_str().unwrap_or("");

--- a/crates/keel-enforce/src/violations.rs
+++ b/crates/keel-enforce/src/violations.rs
@@ -5,6 +5,7 @@ use keel_core::types::{EdgeDirection, EdgeKind, NodeKind};
 use keel_parsers::resolver::FileIndex;
 
 use crate::types::{AffectedNode, Violation};
+use crate::violations_util::is_test_file;
 
 // Re-export E004, E005, W001, W002 checkers so engine.rs keeps using violations::*
 pub use crate::violations_extended::{
@@ -176,8 +177,14 @@ pub fn check_broken_callers_with_cache(
 
 /// Check E002: missing_type_hints — function parameters/return lack type annotations.
 /// Only for Python (and JS with JSDoc). TS/Go/Rust are typed by nature.
+/// Skips test files — test helpers rarely need full type annotations.
 pub fn check_missing_type_hints(file: &FileIndex) -> Vec<Violation> {
     let mut violations = Vec::new();
+
+    // Skip test files: test helpers rarely need full type annotations
+    if is_test_file(&file.file_path) {
+        return violations;
+    }
 
     for def in &file.definitions {
         if def.kind != NodeKind::Function {
@@ -230,8 +237,14 @@ pub fn check_missing_type_hints(file: &FileIndex) -> Vec<Violation> {
 }
 
 /// Check E003: missing_docstring — public function has no docstring.
+/// Skips test files — test functions are self-documenting by name.
 pub fn check_missing_docstring(file: &FileIndex) -> Vec<Violation> {
     let mut violations = Vec::new();
+
+    // Skip test files: test functions are self-documenting by name
+    if is_test_file(&file.file_path) {
+        return violations;
+    }
 
     for def in &file.definitions {
         if def.kind != NodeKind::Function {

--- a/crates/keel-enforce/src/violations_util.rs
+++ b/crates/keel-enforce/src/violations_util.rs
@@ -2,8 +2,17 @@
 /// Patterns: *_test.go, test_*.py, *_test.py, *.test.ts, *.spec.ts,
 /// *.test.js, *.spec.js, *_test.rs, tests.rs
 pub fn is_test_file(path: &str) -> bool {
-    let basename = path.rsplit('/').next().unwrap_or(path);
-    let basename = basename.rsplit('\\').next().unwrap_or(basename);
+    let normalized = path.replace('\\', "/");
+
+    // Directory-based: files inside tests/, __tests__/, test/ directories
+    if normalized.contains("/tests/")
+        || normalized.contains("/__tests__/")
+        || normalized.contains("/test/")
+    {
+        return true;
+    }
+
+    let basename = normalized.rsplit('/').next().unwrap_or(&normalized);
 
     // Go: *_test.go
     if basename.ends_with("_test.go") {
@@ -160,5 +169,11 @@ mod tests {
         assert!(is_test_file("src/handler_test.rs"));
         assert!(is_test_file("src/tests.rs"));
         assert!(!is_test_file("src/handler.rs"));
+
+        // Directory-based detection
+        assert!(is_test_file("src/tests/helpers.py"));
+        assert!(is_test_file("project/test/utils.go"));
+        assert!(is_test_file("src/__tests__/handler.ts"));
+        assert!(!is_test_file("src/contest/handler.py")); // "contest" != "test"
     }
 }

--- a/crates/keel-enforce/src/violations_util.rs
+++ b/crates/keel-enforce/src/violations_util.rs
@@ -5,9 +5,13 @@ pub fn is_test_file(path: &str) -> bool {
     let normalized = path.replace('\\', "/");
 
     // Directory-based: files inside tests/, __tests__/, test/ directories
+    // Check both mid-path ("/tests/") and top-level ("tests/") variants
     if normalized.contains("/tests/")
         || normalized.contains("/__tests__/")
         || normalized.contains("/test/")
+        || normalized.starts_with("tests/")
+        || normalized.starts_with("__tests__/")
+        || normalized.starts_with("test/")
     {
         return true;
     }
@@ -175,5 +179,10 @@ mod tests {
         assert!(is_test_file("project/test/utils.go"));
         assert!(is_test_file("src/__tests__/handler.ts"));
         assert!(!is_test_file("src/contest/handler.py")); // "contest" != "test"
+
+        // Top-level test directories (no parent path prefix)
+        assert!(is_test_file("tests/helpers.py"));
+        assert!(is_test_file("test/utils.go"));
+        assert!(is_test_file("__tests__/handler.ts"));
     }
 }

--- a/tests/enforcement/test_docstrings.rs
+++ b/tests/enforcement/test_docstrings.rs
@@ -30,6 +30,25 @@ fn make_file(defs: Vec<Definition>) -> FileIndex {
     }
 }
 
+fn make_file_with_path(path: &str, defs: Vec<Definition>) -> FileIndex {
+    let defs = defs
+        .into_iter()
+        .map(|mut d| {
+            d.file_path = path.to_string();
+            d
+        })
+        .collect();
+    FileIndex {
+        file_path: path.to_string(),
+        content_hash: 0,
+        definitions: defs,
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
 #[test]
 fn test_e003_public_function_missing_docstring() {
     let file = make_file(vec![make_def("process", true, None)]);
@@ -117,4 +136,34 @@ fn test_e003_confidence_is_1() {
     let violations = check_missing_docstring(&file);
 
     assert_eq!(violations[0].confidence, 1.0);
+}
+
+#[test]
+fn test_e003_skips_test_file_by_name() {
+    let file = make_file_with_path(
+        "tests/test_handler.py",
+        vec![make_def("process", true, None)],
+    );
+    let violations = check_missing_docstring(&file);
+    assert!(violations.is_empty(), "E003 should skip test files");
+}
+
+#[test]
+fn test_e003_skips_test_file_in_tests_dir() {
+    let file = make_file_with_path(
+        "src/tests/helpers.py",
+        vec![make_def("process", true, None)],
+    );
+    let violations = check_missing_docstring(&file);
+    assert!(
+        violations.is_empty(),
+        "E003 should skip files in tests/ directory"
+    );
+}
+
+#[test]
+fn test_e003_skips_spec_file() {
+    let file = make_file_with_path("src/handler.spec.ts", vec![make_def("process", true, None)]);
+    let violations = check_missing_docstring(&file);
+    assert!(violations.is_empty(), "E003 should skip .spec files");
 }

--- a/tests/enforcement/test_type_hints.rs
+++ b/tests/enforcement/test_type_hints.rs
@@ -34,6 +34,25 @@ fn make_file(defs: Vec<Definition>) -> FileIndex {
     }
 }
 
+fn make_file_with_path(path: &str, defs: Vec<Definition>) -> FileIndex {
+    let defs = defs
+        .into_iter()
+        .map(|mut d| {
+            d.file_path = path.to_string();
+            d
+        })
+        .collect();
+    FileIndex {
+        file_path: path.to_string(),
+        content_hash: 0,
+        definitions: defs,
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
 #[test]
 fn test_e002_python_missing_type_hints() {
     let file = make_file(vec![make_def("process", true, false)]);
@@ -124,4 +143,37 @@ fn test_e002_confidence_is_1() {
 
     assert_eq!(violations.len(), 1);
     assert_eq!(violations[0].confidence, 1.0);
+}
+
+#[test]
+fn test_e002_skips_test_file_by_name() {
+    let file = make_file_with_path(
+        "tests/test_handler.py",
+        vec![make_def("process", true, false)],
+    );
+    let violations = check_missing_type_hints(&file);
+    assert!(violations.is_empty(), "E002 should skip test files");
+}
+
+#[test]
+fn test_e002_skips_test_file_in_tests_dir() {
+    let file = make_file_with_path(
+        "src/tests/helpers.py",
+        vec![make_def("process", true, false)],
+    );
+    let violations = check_missing_type_hints(&file);
+    assert!(
+        violations.is_empty(),
+        "E002 should skip files in tests/ directory"
+    );
+}
+
+#[test]
+fn test_e002_skips_spec_file() {
+    let file = make_file_with_path(
+        "src/handler.spec.ts",
+        vec![make_def("process", true, false)],
+    );
+    let violations = check_missing_type_hints(&file);
+    assert!(violations.is_empty(), "E002 should skip .spec files");
 }


### PR DESCRIPTION
## Summary
- **Skip E002 (type hints) and E003 (docstrings) in test files** — test helpers rarely need full annotations; reduces false positives on real projects.
- **Extend `is_test_file()`** to detect directory-based test locations (`tests/`, `__tests__/`, `test/`), not just filename patterns.
- **Harden audit checks:**
  - Exclude `<!-- keel:start -->` / `<!-- keel:end -->` blocks from instruction file line counts.
  - Require `.md` files in `.claude/commands/`, not just directory existence.
  - Validate CI config directories contain actual `.yml`/`.yaml` files.
- **Use `ignore::WalkBuilder`** in verification audit to respect `.gitignore`/`.keelignore`, preventing inflated counts from vendored/generated code.
- **Add test command patterns:** `uv run pytest`, `vitest`, `jest`, `playwright`, `bun test`.
- **Add 6 new tests** covering test-file skipping for E002 and E003.
- **Extract `has_subfolder_claude_md`** to `audit/mod.rs` to keep `agent_config.rs` under the 400-line limit.

## Test plan
- [x] `cargo test --workspace` — all 1,326 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `keel compile --changed` — zero errors, zero warnings
- [x] All modified files under 400-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)