### PR TITLE
Economy enforcement: dead code, duplicate bodies, size budgets, progressive adoption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,12 @@ Tier 3: LSP/SCIP (on-demand, optional, >95%)
 | E005 | arity_mismatch | ERROR |
 | W001 | placement | WARNING |
 | W002 | duplicate_name | WARNING |
+| W005 | dead_code | WARNING |
+| W006 | duplicate_implementation | WARNING |
+| W007 | oversized_file | WARNING |
 | S001 | suppressed | INFO |
+
+W005-W007 are the v0.5 "economy" additions — additive only; existing codes/severities/exit codes unchanged.
 
 Every ERROR has `fix_hint`. Every violation has `confidence` (0.0-1.0) and `resolution_tier`.
 

--- a/constitution.md
+++ b/constitution.md
@@ -210,7 +210,14 @@ JSON output schemas are API surfaces. They are frozen and versioned.
 | W002 | duplicate_name | WARNING | Function with same name exists elsewhere |
 | W003 | naming_convention | WARNING | Name doesn't match module naming pattern (Phase 2) |
 | W004 | cross_repo_endpoint | WARNING | Changed endpoint consumed by linked repo (Phase 2) |
+| W005 | dead_code | WARNING | Function has no callers in the graph |
+| W006 | duplicate_implementation | WARNING | Function body identical (whitespace-normalized) to an existing function |
+| W007 | oversized_file | WARNING | File exceeds the configured line budget and grew in this change |
 | S001 | suppressed | INFO | Violation suppressed via inline or config |
+
+W005-W007 are the v0.5 "economy" additions — additive only; existing codes, severities, and exit codes are unchanged.
+
+Progressive adoption (v0.5): E002/E003 on functions unmodified since the last full `keel map` report as WARNING; modified or new functions report as ERROR. A full map re-baselines — escalation state does not survive it, but demoted debt stays visible as WARNING.
 
 **Common fields on all error/warning objects:**
 

--- a/crates/keel-cli/src/commands/map.rs
+++ b/crates/keel-cli/src/commands/map.rs
@@ -99,6 +99,7 @@ pub fn run(
     let mut valid_node_ids: HashSet<u64> = HashSet::new();
 
     // === First pass: create nodes and same-file edges ===
+    let mut body_index: Vec<keel_core::types::BodyIndexEntry> = Vec::new();
     let all_file_data = map_passes::first_pass(
         &entries,
         &cwd,
@@ -115,6 +116,7 @@ pub fn run(
         &mut file_module_ids,
         &mut assigned_hashes,
         &mut valid_node_ids,
+        &mut body_index,
     );
 
     // Build file -> package mapping and cross-package index for monorepo resolution
@@ -230,6 +232,12 @@ pub fn run(
     if let Err(e) = store.update_nodes(node_changes) {
         eprintln!("keel map: failed to update nodes: {}", e);
         return (2, EventMetrics::default());
+    }
+
+    // Refresh the W006 duplicate-implementation index (full rebuild, like
+    // the graph itself).
+    if let Err(e) = store.replace_body_index(body_index) {
+        eprintln!("keel map: failed to update body index: {}", e);
     }
 
     if let Err(e) = store.update_edges(valid_edges) {

--- a/crates/keel-cli/src/commands/map_helpers.rs
+++ b/crates/keel-cli/src/commands/map_helpers.rs
@@ -158,17 +158,26 @@ pub fn make_relative(root: &Path, path: &Path) -> String {
 }
 
 /// Populate hotspot entries by ranking non-module nodes by total connectivity.
+///
+/// Test files are excluded before ranking: test suites routinely call
+/// everything under test, so their functions rack up huge caller counts that
+/// crowd out genuine hotspots (e.g. a test-helper file outranking the actual
+/// most-connected production code) without telling the agent anything useful
+/// about the codebase's real structure.
 pub fn populate_hotspots(
     result: &mut keel_enforce::types::MapResult,
     node_changes: &[NodeChange],
     valid_edges: &[EdgeChange],
 ) {
     use keel_enforce::types::HotspotEntry;
+    use keel_enforce::violations_util::is_test_file;
 
     let nodes: Vec<_> = node_changes
         .iter()
         .filter_map(|c| match c {
-            NodeChange::Add(n) if n.kind != NodeKind::Module => Some(n),
+            NodeChange::Add(n) if n.kind != NodeKind::Module && !is_test_file(&n.file_path) => {
+                Some(n)
+            }
             _ => None,
         })
         .collect();

--- a/crates/keel-cli/src/commands/map_passes.rs
+++ b/crates/keel-cli/src/commands/map_passes.rs
@@ -45,6 +45,7 @@ pub fn first_pass(
     file_module_ids: &mut HashMap<String, u64>,
     assigned_hashes: &mut HashSet<String>,
     valid_node_ids: &mut HashSet<u64>,
+    body_index: &mut Vec<keel_core::types::BodyIndexEntry>,
 ) -> Vec<FileParseData> {
     let mut all_file_data: Vec<FileParseData> = Vec::new();
 
@@ -121,6 +122,22 @@ pub fn first_pass(
                 .entry(def.name.clone())
                 .or_default()
                 .push((file_path.clone(), node_id));
+
+            // Feed the W006 duplicate-implementation index. Trivial bodies
+            // are skipped here only to bound index size; enforcement applies
+            // its own (higher, compile-time-asserted) similarity threshold.
+            if def.kind == NodeKind::Function {
+                let normalized = keel_core::hash::normalize_body(&def.body_text);
+                if normalized.len() >= keel_core::hash::MIN_INDEXED_BODY_LEN {
+                    body_index.push(keel_core::types::BodyIndexEntry {
+                        body_hash: keel_core::hash::hash_normalized_body(&normalized),
+                        node_hash: hash.clone(),
+                        name: def.name.clone(),
+                        file_path: file_path.clone(),
+                        line: def.line_start,
+                    });
+                }
+            }
 
             node_changes.push(NodeChange::Add(GraphNode {
                 id: node_id,

--- a/crates/keel-core/src/config.rs
+++ b/crates/keel-core/src/config.rs
@@ -129,6 +129,24 @@ pub struct EnforceConfig {
     pub docstrings: bool,
     #[serde(default = "default_true")]
     pub placement: bool,
+    /// Progressive adoption: E002/E003 on functions the current change did
+    /// NOT touch (stored hash unchanged) are reported as WARNING instead of
+    /// ERROR, so adopting keel on a legacy repo doesn't flood errors.
+    #[serde(default = "default_true")]
+    pub progressive: bool,
+    /// W005: warn on private functions with no callers in the graph.
+    #[serde(default = "default_true")]
+    pub dead_code: bool,
+    /// W006: warn when a function body is identical (whitespace-normalized)
+    /// to an existing function elsewhere in the graph.
+    #[serde(default = "default_true")]
+    pub duplication: bool,
+    /// W007: warn when a compiled file exceeds `max_file_lines` and grew.
+    #[serde(default = "default_true")]
+    pub oversized_files: bool,
+    /// Line budget used by the W007 oversized-file check.
+    #[serde(default = "default_max_file_lines")]
+    pub max_file_lines: u32,
 }
 
 /// Circuit breaker tuning.
@@ -154,6 +172,9 @@ fn default_max_failures() -> u32 {
 fn default_timeout_seconds() -> u64 {
     60
 }
+fn default_max_file_lines() -> u32 {
+    400
+}
 
 impl Default for EnforceConfig {
     fn default() -> Self {
@@ -161,6 +182,11 @@ impl Default for EnforceConfig {
             type_hints: true,
             docstrings: true,
             placement: true,
+            progressive: true,
+            dead_code: true,
+            duplication: true,
+            oversized_files: true,
+            max_file_lines: 400,
         }
     }
 }

--- a/crates/keel-core/src/config_tests.rs
+++ b/crates/keel-core/src/config_tests.rs
@@ -24,9 +24,14 @@ fn test_roundtrip_all_non_default_values() {
             "rust".to_string(),
         ],
         enforce: EnforceConfig {
-            type_hints: false, // default is true
-            docstrings: false, // default is true
-            placement: false,  // default is true
+            type_hints: false,      // default is true
+            docstrings: false,      // default is true
+            placement: false,       // default is true
+            progressive: false,     // default is true
+            dead_code: false,       // default is true
+            duplication: false,     // default is true
+            oversized_files: false, // default is true
+            max_file_lines: 123,    // default is 400
         },
         circuit_breaker: CircuitBreakerConfig {
             max_failures: 42, // default is 3

--- a/crates/keel-core/src/hash.rs
+++ b/crates/keel-core/src/hash.rs
@@ -65,6 +65,56 @@ pub fn compute_hash_disambiguated(
     base62_encode(hash_value)
 }
 
+/// Normalize a function body for duplicate detection.
+///
+/// Trims each line, drops blank lines, collapses runs of whitespace to a
+/// single space, and rejoins with `\n`. The result is stable across pure
+/// reformatting (re-indentation, added blank lines, realigned arguments).
+///
+/// **Whitespace-level only.** This is deliberately *not* the AST-based
+/// normalization used by [`compute_hash`] and tracked in issue #36: it does
+/// not strip comments, rename locals, or canonicalize syntax. Two bodies that
+/// differ only in identifier names or comments will produce *different*
+/// normalized text here.
+pub fn normalize_body(body: &str) -> String {
+    body.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Minimum normalized body length worth indexing for duplicate detection.
+///
+/// Bodies shorter than this are trivial (`return null;`, `pass`) and collide
+/// constantly without indicating real duplication. Enforcement thresholds must
+/// be **>= this value**: indexing is gated on it, so a lower threshold would
+/// query for bodies that were never indexed.
+pub const MIN_INDEXED_BODY_LEN: usize = 40;
+
+/// Fingerprint an *already normalized* body.
+///
+/// Use this when the caller has already computed [`normalize_body`] — for
+/// example to length-gate against [`MIN_INDEXED_BODY_LEN`] — so the body is
+/// not normalized twice. Passing non-normalized text produces a hash that will
+/// not match [`compute_body_hash`] for the same input.
+pub fn hash_normalized_body(normalized: &str) -> String {
+    base62_encode(xxh64(normalized.as_bytes(), 0))
+}
+
+/// Compute the duplicate-detection fingerprint for a function body.
+///
+/// `body_hash = base62(xxhash64(normalize_body(body)))` — an 11-char string in
+/// the same alphabet as [`compute_hash`], but a *separate* namespace: it keys
+/// the body index, never the node identity.
+///
+/// Convenience wrapper over [`normalize_body`] + [`hash_normalized_body`]; if
+/// you already hold the normalized text, call those directly.
+pub fn compute_body_hash(body: &str) -> String {
+    hash_normalized_body(&normalize_body(body))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -118,5 +168,133 @@ mod tests {
 
         let encoded = base62_encode(1);
         assert_eq!(encoded.len(), 11);
+    }
+
+    // --- body hash (duplicate detection) ---
+
+    #[test]
+    fn test_body_hash_is_deterministic() {
+        let body = "let x = 1;\nreturn x;";
+        assert_eq!(compute_body_hash(body), compute_body_hash(body));
+    }
+
+    #[test]
+    fn test_body_hash_length() {
+        assert_eq!(compute_body_hash("return 1;").len(), 11);
+    }
+
+    /// Pure reformatting must not change the fingerprint.
+    #[test]
+    fn test_body_hash_stable_across_reformatting() {
+        let original = "let x = 1;\nreturn x;";
+        let reformatted = "    let    x   =  1;\n\n\t\treturn x;   \n";
+        assert_eq!(
+            compute_body_hash(original),
+            compute_body_hash(reformatted),
+            "reformatting must not change the body hash"
+        );
+    }
+
+    #[test]
+    fn test_body_hash_stable_across_indent_changes() {
+        let flat = "if (a) {\nreturn 1;\n}";
+        let indented = "        if (a) {\n            return 1;\n        }";
+        assert_eq!(compute_body_hash(flat), compute_body_hash(indented));
+    }
+
+    #[test]
+    fn test_body_hash_stable_across_blank_lines() {
+        let dense = "let x = 1;\nreturn x;";
+        let spaced = "let x = 1;\n\n\n   \n\nreturn x;\n";
+        assert_eq!(compute_body_hash(dense), compute_body_hash(spaced));
+    }
+
+    #[test]
+    fn test_body_hash_differs_for_different_bodies() {
+        assert_ne!(
+            compute_body_hash("return 1;"),
+            compute_body_hash("return 2;")
+        );
+    }
+
+    /// Line order is semantic — reordering must change the fingerprint.
+    #[test]
+    fn test_body_hash_differs_on_reordered_lines() {
+        assert_ne!(
+            compute_body_hash("a();\nb();"),
+            compute_body_hash("b();\na();")
+        );
+    }
+
+    /// Whitespace-level normalization does NOT see through renames — this is
+    /// the documented boundary with issue #36's AST normalization.
+    #[test]
+    fn test_body_hash_differs_on_renamed_locals() {
+        assert_ne!(
+            compute_body_hash("let x = 1;\nreturn x;"),
+            compute_body_hash("let y = 1;\nreturn y;")
+        );
+    }
+
+    #[test]
+    fn test_normalize_body_collapses_whitespace() {
+        assert_eq!(normalize_body("  a   =    1  "), "a = 1");
+    }
+
+    #[test]
+    fn test_normalize_body_drops_blank_lines() {
+        assert_eq!(normalize_body("a;\n\n  \n\nb;"), "a;\nb;");
+    }
+
+    #[test]
+    fn test_normalize_body_empty_input() {
+        assert_eq!(normalize_body(""), "");
+        assert_eq!(normalize_body("   \n\n  \n"), "");
+    }
+
+    /// An empty body still yields a valid, stable fingerprint.
+    #[test]
+    fn test_body_hash_of_empty_body() {
+        let h = compute_body_hash("");
+        assert_eq!(h.len(), 11);
+        assert_eq!(h, compute_body_hash("   \n\n"));
+    }
+
+    /// The body hash is a separate namespace from the node hash.
+    #[test]
+    fn test_body_hash_differs_from_node_hash() {
+        let body = "return 1;";
+        assert_ne!(compute_body_hash(body), compute_hash("", body, ""));
+    }
+
+    /// Callers that already normalized (e.g. to length-gate) must get the same
+    /// fingerprint as the convenience wrapper — no double normalization.
+    #[test]
+    fn test_hash_normalized_body_matches_compute_body_hash() {
+        let body = "   let x = 1;\n\n   return x;  ";
+        assert_eq!(
+            hash_normalized_body(&normalize_body(body)),
+            compute_body_hash(body)
+        );
+    }
+
+    /// Normalizing twice is a no-op, so the split API cannot drift from the
+    /// wrapper even if a caller over-normalizes.
+    #[test]
+    fn test_normalize_body_is_idempotent() {
+        let body = "  a   =  1 \n\n  b = 2  ";
+        let once = normalize_body(body);
+        assert_eq!(normalize_body(&once), once);
+        assert_eq!(hash_normalized_body(&once), compute_body_hash(body));
+    }
+
+    #[test]
+    fn test_min_indexed_body_len_is_sane() {
+        // A trivial body must fall below the gate; a real one above it.
+        assert!(normalize_body("return null;").len() < MIN_INDEXED_BODY_LEN);
+        assert!(
+            normalize_body("let total = 0;\nfor (x of xs) { total += x; }\nreturn total;").len()
+                >= MIN_INDEXED_BODY_LEN
+        );
     }
 }

--- a/crates/keel-core/src/sqlite.rs
+++ b/crates/keel-core/src/sqlite.rs
@@ -1,8 +1,35 @@
-use rusqlite::{params, Connection, Result as SqlResult};
+use rusqlite::{params, Connection};
 
-use crate::types::{ExternalEndpoint, GraphError, GraphNode, NodeKind};
+use crate::types::GraphError;
 
-const SCHEMA_VERSION: u32 = 4;
+/// Module-profile persistence, split out to keep this file under 400 lines.
+#[path = "sqlite_profiles.rs"]
+mod profiles;
+
+const SCHEMA_VERSION: u32 = 5;
+
+/// DDL for the body-hash duplicate index (schema v5).
+///
+/// Shared by `initialize_schema` (fresh databases) and `migrate_v4_to_v5`
+/// (existing ones) so the two can never drift apart. Lookups are by
+/// `body_hash`, so that column carries the index.
+///
+/// The primary key is the composite `(node_hash, file_path, line)`, not
+/// `node_hash` alone: hash disambiguation salts with the file path only, so
+/// two byte-identical definitions in the *same* file share a node hash. A
+/// bare `node_hash` key would let one silently replace the other and make
+/// W006 attribution nondeterministic.
+const BODY_INDEX_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS body_index (
+        node_hash TEXT NOT NULL,
+        body_hash TEXT NOT NULL,
+        name TEXT NOT NULL,
+        file_path TEXT NOT NULL,
+        line INTEGER NOT NULL,
+        PRIMARY KEY (node_hash, file_path, line)
+    );
+    CREATE INDEX IF NOT EXISTS idx_body_index_body_hash ON body_index(body_hash);
+";
 
 /// SQLite-backed implementation of the GraphStore trait.
 pub struct SqliteGraphStore {
@@ -168,6 +195,10 @@ impl SqliteGraphStore {
             ",
         )?;
 
+        // Body-hash duplicate index (schema v5) — shared DDL, see BODY_INDEX_DDL.
+        self.drop_stale_body_index()?;
+        self.conn.execute_batch(BODY_INDEX_DDL)?;
+
         // Set schema version if not present (new databases get current version)
         self.conn.execute(
             "INSERT OR IGNORE INTO keel_meta (key, value) VALUES ('schema_version', ?1)",
@@ -200,6 +231,9 @@ impl SqliteGraphStore {
         }
         if current < 4 {
             self.migrate_v3_to_v4()?;
+        }
+        if current < 5 {
+            self.migrate_v4_to_v5()?;
         }
         Ok(())
     }
@@ -258,6 +292,54 @@ impl SqliteGraphStore {
         Ok(())
     }
 
+    /// Drop `body_index` if it predates the composite primary key.
+    ///
+    /// v5 briefly carried a bare `node_hash` primary key, which silently drops
+    /// duplicate definitions that share a node hash — precisely the case the
+    /// index exists to catch. `CREATE TABLE IF NOT EXISTS` cannot fix an
+    /// existing table, and a v5 database skips migrations entirely, so detect
+    /// the old shape and recreate it.
+    ///
+    /// Cheap and safe: the index is a derived cache that `keel map` rebuilds.
+    /// Removable once v5 has shipped and no stale databases remain.
+    fn drop_stale_body_index(&self) -> Result<(), GraphError> {
+        let existing: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'body_index'",
+                [],
+                |row| row.get(0),
+            )
+            .ok();
+        if let Some(sql) = existing {
+            if !sql.contains("PRIMARY KEY (node_hash, file_path, line)") {
+                self.conn.execute_batch("DROP TABLE body_index")?;
+                // Otherwise W006 goes silent until the next map and reads
+                // as a regression instead of a schema refresh.
+                eprintln!(
+                    "keel: body index schema updated — run `keel map` to \
+                     rebuild duplicate detection"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Migrate from schema v4 to v5: add the body-hash duplicate index.
+    ///
+    /// Purely additive. `initialize_schema` has already run its
+    /// `CREATE TABLE IF NOT EXISTS`, so the table and index exist by the time
+    /// migrations run; they are repeated here so the step is self-contained
+    /// and safe to run against a v4 database opened by any path.
+    fn migrate_v4_to_v5(&self) -> Result<(), GraphError> {
+        self.conn.execute_batch(BODY_INDEX_DDL)?;
+        self.conn.execute(
+            "UPDATE keel_meta SET value = '5' WHERE key = 'schema_version'",
+            [],
+        )?;
+        Ok(())
+    }
+
     /// Get the current schema version.
     pub fn schema_version(&self) -> Result<u32, GraphError> {
         let version: String = self.conn.query_row(
@@ -290,152 +372,10 @@ impl SqliteGraphStore {
             DELETE FROM module_profiles;
             DELETE FROM external_endpoints;
             DELETE FROM previous_hashes;
+            DELETE FROM body_index;
             DELETE FROM nodes;
             ",
         )?;
-        Ok(())
-    }
-
-    /// Convert a SQLite row into a `GraphNode` (without relations loaded).
-    pub(crate) fn row_to_node(row: &rusqlite::Row) -> SqlResult<GraphNode> {
-        let kind_str: String = row.get("kind")?;
-        let kind = match kind_str.as_str() {
-            "module" => NodeKind::Module,
-            "class" => NodeKind::Class,
-            "function" => NodeKind::Function,
-            _ => NodeKind::Function, // fallback
-        };
-        Ok(GraphNode {
-            id: row.get("id")?,
-            hash: row.get("hash")?,
-            kind,
-            name: row.get("name")?,
-            signature: row.get("signature")?,
-            file_path: row.get("file_path")?,
-            line_start: row.get("line_start")?,
-            line_end: row.get("line_end")?,
-            docstring: row.get("docstring")?,
-            is_public: row.get::<_, i32>("is_public")? != 0,
-            type_hints_present: row.get::<_, i32>("type_hints_present")? != 0,
-            has_docstring: row.get::<_, i32>("has_docstring")? != 0,
-            external_endpoints: Vec::new(), // loaded separately
-            previous_hashes: Vec::new(),    // loaded separately
-            module_id: row.get::<_, Option<u64>>("module_id")?.unwrap_or(0),
-            package: row.get::<_, Option<String>>("package").unwrap_or(None),
-        })
-    }
-
-    /// Load all external endpoints associated with a given node.
-    pub(crate) fn load_endpoints(&self, node_id: u64) -> Vec<ExternalEndpoint> {
-        let mut stmt = match self.conn.prepare(
-            "SELECT kind, method, path, direction FROM external_endpoints WHERE node_id = ?1",
-        ) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[keel] load_endpoints: prepare failed: {e}");
-                return Vec::new();
-            }
-        };
-
-        let result = match stmt.query_map(params![node_id], |row| {
-            Ok(ExternalEndpoint {
-                kind: row.get(0)?,
-                method: row.get(1)?,
-                path: row.get(2)?,
-                direction: row.get(3)?,
-            })
-        }) {
-            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
-            Err(e) => {
-                eprintln!("[keel] load_endpoints: query failed: {e}");
-                Vec::new()
-            }
-        };
-        result
-    }
-
-    /// Load the most recent previous hashes for a node (up to 3, newest first).
-    pub(crate) fn load_previous_hashes(&self, node_id: u64) -> Vec<String> {
-        let mut stmt = match self.conn.prepare(
-            "SELECT hash FROM previous_hashes WHERE node_id = ?1 ORDER BY created_at DESC LIMIT 3",
-        ) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[keel] load_previous_hashes: prepare failed: {e}");
-                return Vec::new();
-            }
-        };
-
-        let result = match stmt.query_map(params![node_id], |row| row.get(0)) {
-            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
-            Err(e) => {
-                eprintln!("[keel] load_previous_hashes: query failed: {e}");
-                Vec::new()
-            }
-        };
-        result
-    }
-
-    /// Attach endpoints and previous hashes to a node, returning the enriched node.
-    pub(crate) fn node_with_relations(&self, mut node: GraphNode) -> GraphNode {
-        node.external_endpoints = self.load_endpoints(node.id);
-        node.previous_hashes = self.load_previous_hashes(node.id);
-        node
-    }
-
-    /// Insert or update module profiles in bulk.
-    /// Uses INSERT ... ON CONFLICT DO UPDATE for upsert semantics.
-    pub fn upsert_module_profiles(
-        &self,
-        profiles: Vec<crate::types::ModuleProfile>,
-    ) -> Result<(), GraphError> {
-        let tx = self.conn.unchecked_transaction()?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO module_profiles (
-                    module_id, path, function_count, class_count, line_count,
-                    function_name_prefixes, primary_types, import_sources,
-                    export_targets, external_endpoint_count, responsibility_keywords
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
-                ON CONFLICT(module_id) DO UPDATE SET
-                    path = excluded.path,
-                    function_count = excluded.function_count,
-                    class_count = excluded.class_count,
-                    line_count = excluded.line_count,
-                    function_name_prefixes = excluded.function_name_prefixes,
-                    primary_types = excluded.primary_types,
-                    import_sources = excluded.import_sources,
-                    export_targets = excluded.export_targets,
-                    external_endpoint_count = excluded.external_endpoint_count,
-                    responsibility_keywords = excluded.responsibility_keywords",
-            )?;
-            for p in &profiles {
-                let prefixes_json = serde_json::to_string(&p.function_name_prefixes)
-                    .unwrap_or_else(|_| "[]".to_string());
-                let types_json =
-                    serde_json::to_string(&p.primary_types).unwrap_or_else(|_| "[]".to_string());
-                let imports_json =
-                    serde_json::to_string(&p.import_sources).unwrap_or_else(|_| "[]".to_string());
-                let exports_json =
-                    serde_json::to_string(&p.export_targets).unwrap_or_else(|_| "[]".to_string());
-                let keywords_json = serde_json::to_string(&p.responsibility_keywords)
-                    .unwrap_or_else(|_| "[]".to_string());
-                stmt.execute(params![
-                    p.module_id,
-                    p.path,
-                    p.function_count,
-                    p.class_count,
-                    p.line_count,
-                    prefixes_json,
-                    types_json,
-                    imports_json,
-                    exports_json,
-                    p.external_endpoint_count,
-                    keywords_json,
-                ])?;
-            }
-        }
-        tx.commit()?;
         Ok(())
     }
 }

--- a/crates/keel-core/src/sqlite_body_index_tests.rs
+++ b/crates/keel-core/src/sqlite_body_index_tests.rs
@@ -1,0 +1,304 @@
+//! Tests for the body-hash duplicate index (schema v5).
+//!
+//! Split from `sqlite_tests.rs` to keep both files under the 400-line cap.
+
+use super::*;
+use crate::store::GraphStore;
+use crate::types::BodyIndexEntry;
+
+fn entry(node_hash: &str, body_hash: &str, name: &str, file: &str, line: u32) -> BodyIndexEntry {
+    BodyIndexEntry {
+        body_hash: body_hash.to_string(),
+        node_hash: node_hash.to_string(),
+        name: name.to_string(),
+        file_path: file.to_string(),
+        line,
+    }
+}
+
+#[test]
+fn test_body_index_roundtrip() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![entry("node1", "bodyAAA", "parse", "src/a.rs", 10)])
+        .expect("replace should succeed");
+
+    let found = store.find_body_matches("bodyAAA");
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0], entry("node1", "bodyAAA", "parse", "src/a.rs", 10));
+}
+
+/// The point of the index: two nodes sharing a body hash are both returned.
+#[test]
+fn test_body_index_finds_all_duplicates() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![
+            entry("node1", "dupBody", "parse", "src/a.rs", 10),
+            entry("node2", "dupBody", "parseAgain", "src/b.rs", 20),
+            entry("node3", "otherBody", "unrelated", "src/c.rs", 30),
+        ])
+        .unwrap();
+
+    let dups = store.find_body_matches("dupBody");
+    assert_eq!(dups.len(), 2, "both duplicates should be returned");
+    let names: Vec<&str> = dups.iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"parse"));
+    assert!(names.contains(&"parseAgain"));
+
+    assert_eq!(store.find_body_matches("otherBody").len(), 1);
+}
+
+#[test]
+fn test_body_index_replace_overwrites_previous_contents() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![entry("old1", "oldBody", "gone", "src/old.rs", 1)])
+        .unwrap();
+    assert_eq!(store.find_body_matches("oldBody").len(), 1);
+
+    // A second replace is a full rebuild, not a merge.
+    store
+        .replace_body_index(vec![entry("new1", "newBody", "kept", "src/new.rs", 2)])
+        .unwrap();
+
+    assert!(
+        store.find_body_matches("oldBody").is_empty(),
+        "stale entries must not survive a rebuild"
+    );
+    assert_eq!(store.find_body_matches("newBody").len(), 1);
+}
+
+#[test]
+fn test_body_index_replace_with_empty_clears_index() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![entry("n1", "someBody", "f", "src/a.rs", 1)])
+        .unwrap();
+
+    store.replace_body_index(Vec::new()).unwrap();
+    assert!(store.find_body_matches("someBody").is_empty());
+}
+
+#[test]
+fn test_body_index_find_on_empty_index() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    assert!(store.find_body_matches("anything").is_empty());
+}
+
+#[test]
+fn test_body_index_find_unknown_hash() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![entry("n1", "known", "f", "src/a.rs", 1)])
+        .unwrap();
+    assert!(store.find_body_matches("unknown").is_empty());
+}
+
+/// Hash disambiguation salts with the file path only, so two byte-identical
+/// definitions in the *same* file share a node hash. Both must survive — a
+/// bare `node_hash` primary key silently dropped one, making W006 attribution
+/// nondeterministic.
+#[test]
+fn test_same_node_hash_different_lines_both_survive() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![
+            entry("dupHash", "sharedBody", "helper", "src/a.rs", 10),
+            entry("dupHash", "sharedBody", "helper", "src/a.rs", 40),
+        ])
+        .expect("identical node_hash on different lines must not collide");
+
+    let found = store.find_body_matches("sharedBody");
+    assert_eq!(found.len(), 2, "both definitions must be indexed");
+    let lines: Vec<u32> = found.iter().map(|e| e.line).collect();
+    assert_eq!(lines, vec![10, 40], "ordered by file_path, line");
+}
+
+/// The same node hash in two different files is also distinct.
+#[test]
+fn test_same_node_hash_different_files_both_survive() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![
+            entry("dupHash", "sharedBody", "helper", "src/a.rs", 1),
+            entry("dupHash", "sharedBody", "helper", "src/b.rs", 1),
+        ])
+        .unwrap();
+
+    assert_eq!(store.find_body_matches("sharedBody").len(), 2);
+}
+
+/// `(node_hash, file_path, line)` is the primary key, so re-indexing the exact
+/// same location in one batch must not blow up on a constraint violation.
+#[test]
+fn test_body_index_duplicate_node_hash_in_batch() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![
+            entry("sameNode", "bodyA", "first", "src/a.rs", 1),
+            entry("sameNode", "bodyB", "second", "src/a.rs", 1),
+        ])
+        .expect("duplicate node_hash must not error");
+
+    // Last write wins.
+    assert!(store.find_body_matches("bodyA").is_empty());
+    assert_eq!(store.find_body_matches("bodyB").len(), 1);
+}
+
+#[test]
+fn test_clear_all_wipes_body_index() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![entry("n1", "someBody", "f", "src/a.rs", 1)])
+        .unwrap();
+
+    store.clear_all().unwrap();
+    assert!(
+        store.find_body_matches("someBody").is_empty(),
+        "clear_all must wipe the body index for a clean re-map"
+    );
+}
+
+#[test]
+fn test_fresh_database_is_v5() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    assert_eq!(store.schema_version().unwrap(), 5);
+}
+
+/// A v4 database must migrate to v5 and gain a usable body index, with its
+/// existing rows intact.
+#[test]
+fn test_migration_v4_to_v5() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("v4.db");
+    let db_str = db_path.to_str().unwrap();
+
+    // GIVEN a v4 database holding a node.
+    {
+        let store = SqliteGraphStore::open(db_str).unwrap();
+        store
+            .conn
+            .execute_batch(
+                "INSERT INTO nodes (hash, kind, name, file_path, line_start, line_end)
+                 VALUES ('keepme', 'function', 'survivor', 'src/a.rs', 1, 5);
+                 DROP TABLE body_index;
+                 UPDATE keel_meta SET value = '4' WHERE key = 'schema_version';",
+            )
+            .unwrap();
+    }
+
+    // WHEN reopened with v5 code.
+    let mut store = SqliteGraphStore::open(db_str).unwrap();
+
+    // THEN the version advanced and the index works.
+    assert_eq!(store.schema_version().unwrap(), 5, "v4 db should reach v5");
+    store
+        .replace_body_index(vec![entry("n1", "b1", "f", "src/a.rs", 1)])
+        .expect("body index usable after migration");
+    assert_eq!(store.find_body_matches("b1").len(), 1);
+
+    // AND the pre-existing data survived.
+    assert!(
+        store.get_node("keepme").is_some(),
+        "migration must preserve existing rows"
+    );
+}
+
+/// Reopening an already-migrated database must be a no-op, not a re-migration
+/// that wipes the index.
+#[test]
+fn test_migration_v5_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("v5.db");
+    let db_str = db_path.to_str().unwrap();
+
+    {
+        let mut store = SqliteGraphStore::open(db_str).unwrap();
+        store
+            .replace_body_index(vec![entry("n1", "persisted", "f", "src/a.rs", 1)])
+            .unwrap();
+    }
+
+    let store = SqliteGraphStore::open(db_str).unwrap();
+    assert_eq!(store.schema_version().unwrap(), 5);
+    assert_eq!(
+        store.find_body_matches("persisted").len(),
+        1,
+        "reopening must not drop indexed entries"
+    );
+}
+
+/// A database carrying the pre-fix `node_hash`-only primary key must be
+/// recreated on open, not silently kept — otherwise it keeps dropping rows.
+#[test]
+fn test_stale_body_index_schema_is_recreated() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("stale.db");
+    let db_str = db_path.to_str().unwrap();
+
+    // GIVEN a database with the old, unsound single-column primary key.
+    {
+        let store = SqliteGraphStore::open(db_str).unwrap();
+        store
+            .conn
+            .execute_batch(
+                "DROP TABLE body_index;
+                 CREATE TABLE body_index (
+                     node_hash TEXT PRIMARY KEY,
+                     body_hash TEXT NOT NULL,
+                     name TEXT NOT NULL,
+                     file_path TEXT NOT NULL,
+                     line INTEGER NOT NULL
+                 );",
+            )
+            .unwrap();
+    }
+
+    // WHEN reopened, THEN the composite key is in force and both rows persist.
+    let mut store = SqliteGraphStore::open(db_str).unwrap();
+    store
+        .replace_body_index(vec![
+            entry("dupHash", "sharedBody", "helper", "src/a.rs", 10),
+            entry("dupHash", "sharedBody", "helper", "src/a.rs", 40),
+        ])
+        .expect("stale schema should have been recreated");
+    assert_eq!(store.find_body_matches("sharedBody").len(), 2);
+}
+
+/// End-to-end with the real hasher: reformatted copies of the same function
+/// collide in the index, which is what W006 will key on.
+#[test]
+fn test_body_index_with_real_body_hashes() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+
+    let original = "let total = 0;\nfor (x of xs) { total += x; }\nreturn total;";
+    let reformatted =
+        "    let total = 0;\n\n    for (x of xs) {   total += x; }\n    return total;";
+    let different = "return xs.reduce((a, b) => a + b, 0);";
+
+    let h_original = crate::hash::compute_body_hash(original);
+    let h_different = crate::hash::compute_body_hash(different);
+
+    store
+        .replace_body_index(vec![
+            entry("nodeA", &h_original, "sumLoop", "src/a.rs", 10),
+            entry(
+                "nodeB",
+                &crate::hash::compute_body_hash(reformatted),
+                "sumLoopCopy",
+                "src/b.rs",
+                20,
+            ),
+            entry("nodeC", &h_different, "sumReduce", "src/c.rs", 30),
+        ])
+        .unwrap();
+
+    let dups = store.find_body_matches(&h_original);
+    assert_eq!(
+        dups.len(),
+        2,
+        "reformatted copy should collide with the original"
+    );
+    assert_eq!(store.find_body_matches(&h_different).len(), 1);
+}

--- a/crates/keel-core/src/sqlite_helpers.rs
+++ b/crates/keel-core/src/sqlite_helpers.rs
@@ -1,10 +1,77 @@
-use rusqlite::params;
+use rusqlite::{params, Result as SqlResult};
 
 use crate::sqlite::SqliteGraphStore;
 use crate::store::GraphStore;
-use crate::types::{GraphError, GraphNode};
+use crate::types::{BodyIndexEntry, ExternalEndpoint, GraphError, GraphNode, NodeKind};
 
 impl SqliteGraphStore {
+    /// Rebuild the body-hash index from `entries` in a single transaction.
+    ///
+    /// Backs [`GraphStore::replace_body_index`]. The delete and the inserts
+    /// share one transaction so a concurrent reader never sees a partially
+    /// rebuilt index.
+    pub(crate) fn body_index_replace(
+        &self,
+        entries: Vec<BodyIndexEntry>,
+    ) -> Result<(), GraphError> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute("DELETE FROM body_index", [])?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR REPLACE INTO body_index
+                 (node_hash, body_hash, name, file_path, line)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for e in &entries {
+                stmt.execute(params![
+                    e.node_hash,
+                    e.body_hash,
+                    e.name,
+                    e.file_path,
+                    e.line
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Look up every indexed node sharing `body_hash`.
+    ///
+    /// Backs [`GraphStore::find_body_matches`]. Uses `idx_body_index_body_hash`.
+    pub(crate) fn body_index_find(&self, body_hash: &str) -> Vec<BodyIndexEntry> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT node_hash, body_hash, name, file_path, line
+             FROM body_index WHERE body_hash = ?1
+             ORDER BY file_path, line",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[keel] body_index_find: prepare failed: {e}");
+                return Vec::new();
+            }
+        };
+
+        // Bind before returning: the `MappedRows` temporary borrows `stmt`, so
+        // using the match as the tail expression outlives `stmt` (E0597).
+        let result = match stmt.query_map(params![body_hash], |row| {
+            Ok(BodyIndexEntry {
+                node_hash: row.get(0)?,
+                body_hash: row.get(1)?,
+                name: row.get(2)?,
+                file_path: row.get(3)?,
+                line: row.get(4)?,
+            })
+        }) {
+            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+            Err(e) => {
+                eprintln!("[keel] body_index_find: query failed: {e}");
+                Vec::new()
+            }
+        };
+        result
+    }
+
     /// Load circuit breaker state from the database.
     pub fn load_circuit_breaker(&self) -> Result<Vec<(String, String, u32, bool)>, GraphError> {
         let mut stmt = self.conn.prepare(
@@ -148,6 +215,28 @@ impl SqliteGraphStore {
         Ok(())
     }
 
+    /// Append rename history for a node, inside an open transaction.
+    ///
+    /// **Append-only by design.** Parsers routinely build `GraphNode` values
+    /// with an empty `previous_hashes`, so replacing the set here would erase
+    /// accumulated history on every re-map of an unchanged file. Entries are
+    /// only ever added; a full `keel map` re-baselines them via `clear_all`.
+    ///
+    /// The `(node_id, hash)` primary key makes repeated writes idempotent.
+    pub(crate) fn append_previous_hashes(
+        tx: &rusqlite::Transaction<'_>,
+        node_id: u64,
+        hashes: &[String],
+    ) -> Result<(), GraphError> {
+        for hash in hashes {
+            tx.execute(
+                "INSERT OR IGNORE INTO previous_hashes (node_id, hash) VALUES (?1, ?2)",
+                params![node_id, hash],
+            )?;
+        }
+        Ok(())
+    }
+
     /// Update an existing node by ID, preserving the old hash in previous_hashes.
     pub fn update_node_in_db(&self, node: &GraphNode) -> Result<(), GraphError> {
         // Store old hash as previous hash
@@ -197,5 +286,92 @@ impl SqliteGraphStore {
         }
 
         Ok(())
+    }
+
+    /// Convert a SQLite row into a `GraphNode` (without relations loaded).
+    pub(crate) fn row_to_node(row: &rusqlite::Row) -> SqlResult<GraphNode> {
+        let kind_str: String = row.get("kind")?;
+        let kind = match kind_str.as_str() {
+            "module" => NodeKind::Module,
+            "class" => NodeKind::Class,
+            "function" => NodeKind::Function,
+            _ => NodeKind::Function, // fallback
+        };
+        Ok(GraphNode {
+            id: row.get("id")?,
+            hash: row.get("hash")?,
+            kind,
+            name: row.get("name")?,
+            signature: row.get("signature")?,
+            file_path: row.get("file_path")?,
+            line_start: row.get("line_start")?,
+            line_end: row.get("line_end")?,
+            docstring: row.get("docstring")?,
+            is_public: row.get::<_, i32>("is_public")? != 0,
+            type_hints_present: row.get::<_, i32>("type_hints_present")? != 0,
+            has_docstring: row.get::<_, i32>("has_docstring")? != 0,
+            external_endpoints: Vec::new(), // loaded separately
+            previous_hashes: Vec::new(),    // loaded separately
+            module_id: row.get::<_, Option<u64>>("module_id")?.unwrap_or(0),
+            package: row.get::<_, Option<String>>("package").unwrap_or(None),
+        })
+    }
+
+    /// Load all external endpoints associated with a given node.
+    pub(crate) fn load_endpoints(&self, node_id: u64) -> Vec<ExternalEndpoint> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT kind, method, path, direction FROM external_endpoints WHERE node_id = ?1",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[keel] load_endpoints: prepare failed: {e}");
+                return Vec::new();
+            }
+        };
+
+        let result = match stmt.query_map(params![node_id], |row| {
+            Ok(ExternalEndpoint {
+                kind: row.get(0)?,
+                method: row.get(1)?,
+                path: row.get(2)?,
+                direction: row.get(3)?,
+            })
+        }) {
+            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+            Err(e) => {
+                eprintln!("[keel] load_endpoints: query failed: {e}");
+                Vec::new()
+            }
+        };
+        result
+    }
+
+    /// Load the most recent previous hashes for a node (up to 3, newest first).
+    pub(crate) fn load_previous_hashes(&self, node_id: u64) -> Vec<String> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT hash FROM previous_hashes WHERE node_id = ?1 ORDER BY created_at DESC LIMIT 3",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[keel] load_previous_hashes: prepare failed: {e}");
+                return Vec::new();
+            }
+        };
+
+        let result = match stmt.query_map(params![node_id], |row| row.get(0)) {
+            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+            Err(e) => {
+                eprintln!("[keel] load_previous_hashes: query failed: {e}");
+                Vec::new()
+            }
+        };
+        result
+    }
+
+    /// Attach endpoints and previous hashes to a node, returning the enriched node.
+    pub(crate) fn node_with_relations(&self, mut node: GraphNode) -> GraphNode {
+        node.external_endpoints = self.load_endpoints(node.id);
+        node.previous_hashes = self.load_previous_hashes(node.id);
+        node
     }
 }

--- a/crates/keel-core/src/sqlite_previous_hashes_tests.rs
+++ b/crates/keel-core/src/sqlite_previous_hashes_tests.rs
@@ -1,0 +1,125 @@
+//! Tests for `previous_hashes` persistence through `GraphStore::update_nodes`.
+//!
+//! Progressive adoption reads this field back to mean "modified since the last
+//! map", so the write path must not drop it. Split from `sqlite_tests.rs` to
+//! keep both files under the 400-line cap.
+
+use super::*;
+
+/// `update_nodes` used to drop `previous_hashes` on the floor; progressive
+/// adoption reads it back to mean "modified since last map".
+#[test]
+fn test_update_nodes_persists_previous_hashes_on_update() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let node = test_node(1, "newHash0001", "renamed_fn");
+    store
+        .update_nodes(vec![NodeChange::Add(node.clone())])
+        .unwrap();
+
+    let mut changed = node.clone();
+    changed.previous_hashes = vec!["old".to_string()];
+    store
+        .update_nodes(vec![NodeChange::Update(changed)])
+        .unwrap();
+
+    let read_back = store.get_nodes_in_file("src/test.rs");
+    assert_eq!(read_back.len(), 1);
+    assert_eq!(
+        read_back[0].previous_hashes,
+        vec!["old".to_string()],
+        "previous_hashes must survive a round trip through update_nodes"
+    );
+}
+
+#[test]
+fn test_update_nodes_persists_previous_hashes_on_add() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let mut node = test_node(1, "abc12345678", "fresh_fn");
+    node.previous_hashes = vec!["priorHash01".to_string()];
+
+    store.update_nodes(vec![NodeChange::Add(node)]).unwrap();
+
+    let read_back = store.get_nodes_in_file("src/test.rs");
+    assert_eq!(
+        read_back[0].previous_hashes,
+        vec!["priorHash01".to_string()]
+    );
+}
+
+/// Appending is cumulative across syncs, and idempotent — the engine may
+/// replay the same old hash without duplicating it.
+#[test]
+fn test_previous_hashes_accumulate_and_dedupe() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let node = test_node(1, "hash0000001", "evolving_fn");
+    store
+        .update_nodes(vec![NodeChange::Add(node.clone())])
+        .unwrap();
+
+    for hash in ["gen1", "gen1", "gen2"] {
+        let mut changed = node.clone();
+        changed.previous_hashes = vec![hash.to_string()];
+        store
+            .update_nodes(vec![NodeChange::Update(changed)])
+            .unwrap();
+    }
+
+    let mut found = store.get_nodes_in_file("src/test.rs")[0]
+        .previous_hashes
+        .clone();
+    found.sort();
+    assert_eq!(found, vec!["gen1".to_string(), "gen2".to_string()]);
+}
+
+/// A node carrying no rename history must not erase history already recorded
+/// — parsers construct nodes with an empty vec on every re-map.
+#[test]
+fn test_empty_previous_hashes_does_not_erase_history() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let node = test_node(1, "hash0000002", "stable_fn");
+    store
+        .update_nodes(vec![NodeChange::Add(node.clone())])
+        .unwrap();
+
+    let mut with_history = node.clone();
+    with_history.previous_hashes = vec!["keepme".to_string()];
+    store
+        .update_nodes(vec![NodeChange::Update(with_history)])
+        .unwrap();
+
+    // Re-map style write: same node, no history attached.
+    store.update_nodes(vec![NodeChange::Update(node)]).unwrap();
+
+    assert_eq!(
+        store.get_nodes_in_file("src/test.rs")[0].previous_hashes,
+        vec!["keepme".to_string()],
+        "an empty previous_hashes must be a no-op, not a wipe"
+    );
+}
+
+/// `clear_all` is the intended re-baseline for progressive adoption.
+#[test]
+fn test_clear_all_resets_previous_hashes() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let mut node = test_node(1, "hash0000003", "fn_with_history");
+    node.previous_hashes = vec!["old".to_string()];
+    store
+        .update_nodes(vec![NodeChange::Add(node.clone())])
+        .unwrap();
+
+    store.clear_all().unwrap();
+    store
+        .update_nodes(vec![NodeChange::Add(test_node(
+            1,
+            "hash0000003",
+            "fn_with_history",
+        ))])
+        .unwrap();
+
+    assert!(
+        store.get_nodes_in_file("src/test.rs")[0]
+            .previous_hashes
+            .is_empty(),
+        "a full re-map should re-baseline history"
+    );
+}

--- a/crates/keel-core/src/sqlite_profiles.rs
+++ b/crates/keel-core/src/sqlite_profiles.rs
@@ -1,0 +1,66 @@
+//! Module-profile persistence for the SQLite graph store.
+//!
+//! Split from `sqlite.rs` to keep that file under the 400-line cap.
+
+use rusqlite::params;
+
+use crate::sqlite::SqliteGraphStore;
+use crate::types::GraphError;
+
+impl SqliteGraphStore {
+    /// Insert or update module profiles in bulk.
+    /// Uses INSERT ... ON CONFLICT DO UPDATE for upsert semantics.
+    pub fn upsert_module_profiles(
+        &self,
+        profiles: Vec<crate::types::ModuleProfile>,
+    ) -> Result<(), GraphError> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO module_profiles (
+                    module_id, path, function_count, class_count, line_count,
+                    function_name_prefixes, primary_types, import_sources,
+                    export_targets, external_endpoint_count, responsibility_keywords
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                ON CONFLICT(module_id) DO UPDATE SET
+                    path = excluded.path,
+                    function_count = excluded.function_count,
+                    class_count = excluded.class_count,
+                    line_count = excluded.line_count,
+                    function_name_prefixes = excluded.function_name_prefixes,
+                    primary_types = excluded.primary_types,
+                    import_sources = excluded.import_sources,
+                    export_targets = excluded.export_targets,
+                    external_endpoint_count = excluded.external_endpoint_count,
+                    responsibility_keywords = excluded.responsibility_keywords",
+            )?;
+            for p in &profiles {
+                let prefixes_json = serde_json::to_string(&p.function_name_prefixes)
+                    .unwrap_or_else(|_| "[]".to_string());
+                let types_json =
+                    serde_json::to_string(&p.primary_types).unwrap_or_else(|_| "[]".to_string());
+                let imports_json =
+                    serde_json::to_string(&p.import_sources).unwrap_or_else(|_| "[]".to_string());
+                let exports_json =
+                    serde_json::to_string(&p.export_targets).unwrap_or_else(|_| "[]".to_string());
+                let keywords_json = serde_json::to_string(&p.responsibility_keywords)
+                    .unwrap_or_else(|_| "[]".to_string());
+                stmt.execute(params![
+                    p.module_id,
+                    p.path,
+                    p.function_count,
+                    p.class_count,
+                    p.line_count,
+                    prefixes_json,
+                    types_json,
+                    imports_json,
+                    exports_json,
+                    p.external_endpoint_count,
+                    keywords_json,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+}

--- a/crates/keel-core/src/sqlite_queries.rs
+++ b/crates/keel-core/src/sqlite_queries.rs
@@ -3,8 +3,8 @@ use rusqlite::params;
 use crate::sqlite::SqliteGraphStore;
 use crate::store::GraphStore;
 use crate::types::{
-    EdgeChange, EdgeDirection, EdgeKind, GraphEdge, GraphError, GraphNode, ModuleProfile,
-    NodeChange,
+    BodyIndexEntry, EdgeChange, EdgeDirection, EdgeKind, GraphEdge, GraphError, GraphNode,
+    ModuleProfile, NodeChange,
 };
 
 impl GraphStore for SqliteGraphStore {
@@ -212,6 +212,18 @@ impl GraphStore for SqliteGraphStore {
                             node.package,
                         ],
                     )?;
+
+                    // ON CONFLICT(hash) updates the pre-existing row, which
+                    // keeps its own id — so resolve the stored id rather than
+                    // trusting node.id before writing child rows.
+                    if !node.previous_hashes.is_empty() {
+                        let stored_id: u64 = tx.query_row(
+                            "SELECT id FROM nodes WHERE hash = ?1",
+                            params![node.hash],
+                            |row| row.get(0),
+                        )?;
+                        Self::append_previous_hashes(&tx, stored_id, &node.previous_hashes)?;
+                    }
                 }
                 NodeChange::Update(node) => {
                     // Check for hash collision (different node, same hash)
@@ -250,6 +262,9 @@ impl GraphStore for SqliteGraphStore {
                             node.id,
                         ],
                     )?;
+
+                    // Update targets a known id, so no lookup is needed here.
+                    Self::append_previous_hashes(&tx, node.id, &node.previous_hashes)?;
                 }
                 NodeChange::Remove(id) => {
                     tx.execute("DELETE FROM nodes WHERE id = ?1", params![id])?;
@@ -369,5 +384,13 @@ impl GraphStore for SqliteGraphStore {
                 Vec::new()
             }
         }
+    }
+
+    fn replace_body_index(&mut self, entries: Vec<BodyIndexEntry>) -> Result<(), GraphError> {
+        self.body_index_replace(entries)
+    }
+
+    fn find_body_matches(&self, body_hash: &str) -> Vec<BodyIndexEntry> {
+        self.body_index_find(body_hash)
     }
 }

--- a/crates/keel-core/src/sqlite_tests.rs
+++ b/crates/keel-core/src/sqlite_tests.rs
@@ -1,6 +1,14 @@
 use super::*;
 use crate::store::GraphStore;
-use crate::types::{EdgeChange, EdgeDirection, EdgeKind, GraphEdge, NodeChange, NodeKind};
+use crate::types::{
+    EdgeChange, EdgeDirection, EdgeKind, GraphEdge, GraphNode, NodeChange, NodeKind,
+};
+
+#[path = "sqlite_body_index_tests.rs"]
+mod body_index;
+
+#[path = "sqlite_previous_hashes_tests.rs"]
+mod previous_hashes;
 
 fn test_node(id: u64, hash: &str, name: &str) -> GraphNode {
     GraphNode {

--- a/crates/keel-core/src/store.rs
+++ b/crates/keel-core/src/store.rs
@@ -1,5 +1,6 @@
 use crate::types::{
-    EdgeChange, EdgeDirection, GraphEdge, GraphError, GraphNode, ModuleProfile, NodeChange,
+    BodyIndexEntry, EdgeChange, EdgeDirection, GraphEdge, GraphError, GraphNode, ModuleProfile,
+    NodeChange,
 };
 
 /// FROZEN CONTRACT — GraphStore trait.
@@ -41,4 +42,99 @@ pub trait GraphStore {
     /// Find nodes with the given name and kind, excluding a specific file.
     /// Used by W002 duplicate_name check.
     fn find_nodes_by_name(&self, name: &str, kind: &str, exclude_file: &str) -> Vec<GraphNode>;
+
+    /// Replace the entire body-hash index with `entries`.
+    ///
+    /// Populated during `keel map`. Implementations should apply this
+    /// atomically — the index must never be observed half-rebuilt.
+    ///
+    /// Additive with a no-op default so backends that do not support
+    /// duplicate detection keep compiling; such backends simply report no
+    /// duplicates via [`GraphStore::find_body_matches`].
+    fn replace_body_index(&mut self, entries: Vec<BodyIndexEntry>) -> Result<(), GraphError> {
+        let _ = entries;
+        Ok(())
+    }
+
+    /// Find every indexed node whose normalized body matches `body_hash`.
+    ///
+    /// Queried by W006 duplicate-implementation enforcement. Returns an empty
+    /// vec when the backend does not maintain a body index (the default).
+    fn find_body_matches(&self, body_hash: &str) -> Vec<BodyIndexEntry> {
+        let _ = body_hash;
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A backend that implements only the pre-v5 required methods.
+    ///
+    /// Its existence is the test: if `replace_body_index` or
+    /// `find_body_matches` ever stops being a defaulted method, this stops
+    /// compiling — which is exactly the additive guarantee we promised
+    /// downstream implementors.
+    struct MinimalStore;
+
+    impl GraphStore for MinimalStore {
+        fn get_node(&self, _hash: &str) -> Option<GraphNode> {
+            None
+        }
+        fn get_node_by_id(&self, _id: u64) -> Option<GraphNode> {
+            None
+        }
+        fn get_edges(&self, _node_id: u64, _direction: EdgeDirection) -> Vec<GraphEdge> {
+            Vec::new()
+        }
+        fn get_module_profile(&self, _module_id: u64) -> Option<ModuleProfile> {
+            None
+        }
+        fn get_nodes_in_file(&self, _file_path: &str) -> Vec<GraphNode> {
+            Vec::new()
+        }
+        fn get_all_modules(&self) -> Vec<GraphNode> {
+            Vec::new()
+        }
+        fn update_nodes(&mut self, _changes: Vec<NodeChange>) -> Result<(), GraphError> {
+            Ok(())
+        }
+        fn update_edges(&mut self, _changes: Vec<EdgeChange>) -> Result<(), GraphError> {
+            Ok(())
+        }
+        fn get_previous_hashes(&self, _node_id: u64) -> Vec<String> {
+            Vec::new()
+        }
+        fn find_modules_by_prefix(&self, _prefix: &str, _exclude_file: &str) -> Vec<ModuleProfile> {
+            Vec::new()
+        }
+        fn find_nodes_by_name(
+            &self,
+            _name: &str,
+            _kind: &str,
+            _exclude_file: &str,
+        ) -> Vec<GraphNode> {
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn test_body_index_defaults_are_no_ops() {
+        let mut store = MinimalStore;
+        store
+            .replace_body_index(vec![BodyIndexEntry {
+                body_hash: "b".into(),
+                node_hash: "n".into(),
+                name: "f".into(),
+                file_path: "src/a.rs".into(),
+                line: 1,
+            }])
+            .expect("default replace_body_index must succeed");
+
+        assert!(
+            store.find_body_matches("b").is_empty(),
+            "a backend without a body index reports no duplicates"
+        );
+    }
 }

--- a/crates/keel-core/src/types.rs
+++ b/crates/keel-core/src/types.rs
@@ -143,6 +143,31 @@ pub enum EdgeChange {
     Remove(u64),
 }
 
+/// One entry in the body-hash duplicate index.
+///
+/// Maps a normalized-body fingerprint (`body_hash`) to the node that produced
+/// it, so nodes sharing a `body_hash` are candidate duplicate implementations.
+/// Populated during `keel map`; queried by W006 duplicate-implementation
+/// enforcement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BodyIndexEntry {
+    /// Fingerprint of the normalized body — see `hash::compute_body_hash`.
+    pub body_hash: String,
+    /// Identity key of the indexed function.
+    ///
+    /// Part of the storage primary key `(node_hash, file_path, line)` — a
+    /// bare `node_hash` is *not* unique, since disambiguation salts with the
+    /// file path only. Not consumed by W006 matching today; matching keys on
+    /// `body_hash`.
+    pub node_hash: String,
+    /// Node name, carried so callers can report duplicates without a join.
+    pub name: String,
+    /// File the node lives in.
+    pub file_path: String,
+    /// Line the node starts on.
+    pub line: u32,
+}
+
 /// Errors that can occur during graph operations.
 #[derive(Debug, thiserror::Error)]
 pub enum GraphError {

--- a/crates/keel-enforce/src/batch.rs
+++ b/crates/keel-enforce/src/batch.rs
@@ -5,7 +5,9 @@ use crate::types::Violation;
 /// Codes that are deferrable in batch mode.
 /// Structural errors (E001, E004, E005) fire immediately.
 /// Type hints (E002), docstrings (E003), placement (W001), duplicates (W002) are deferred.
-const DEFERRABLE_CODES: &[&str] = &["E002", "E003", "W001", "W002"];
+// Economy checks (W005-W007) defer too: mid-scaffold, "no callers yet" and
+// "file still growing" are expected states, not violations.
+const DEFERRABLE_CODES: &[&str] = &["E002", "E003", "W001", "W002", "W005", "W006", "W007"];
 
 /// Maximum time batch mode stays active before auto-expiring.
 const BATCH_TIMEOUT: Duration = Duration::from_secs(60);

--- a/crates/keel-enforce/src/engine.rs
+++ b/crates/keel-enforce/src/engine.rs
@@ -1,13 +1,15 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use keel_core::store::GraphStore;
 use keel_parsers::resolver::FileIndex;
 
 use crate::batch::BatchState;
 use crate::circuit_breaker::{BreakerAction, CircuitBreaker};
+use crate::progressive::apply_progressive_adoption;
 use crate::suppress::SuppressionManager;
 use crate::types::{CompileInfo, CompileResult, Violation};
 use crate::violations;
+use crate::violations_economy;
 
 /// Core enforcement engine. Owns a GraphStore and orchestrates validation.
 pub struct EnforcementEngine {
@@ -56,6 +58,10 @@ impl EnforcementEngine {
         // Build batch file set: callers in the same compile batch are skipped
         // by E001/E004 since the user likely updated them in the same commit.
         let batch_file_set: HashSet<&str> = files.iter().map(|f| f.file_path.as_str()).collect();
+        // Economy-check state shared across the batch: names referenced
+        // anywhere in it (W005) and body hashes seen so far (W006).
+        let referenced_names = violations_economy::batch_reference_names(files);
+        let mut seen_bodies: HashMap<String, (String, String, u32)> = HashMap::new();
 
         for file in files {
             // Pre-fetch existing nodes once — used by E001, E004, and hash tracking
@@ -93,6 +99,31 @@ impl EnforcementEngine {
             }
             // W002: duplicate names
             file_violations.extend(violations::check_duplicate_names(file, &*self.store));
+            // W005: dead code (gated by config)
+            if self.enforce_config.dead_code {
+                file_violations.extend(violations_economy::check_dead_code(
+                    file,
+                    &*self.store,
+                    &existing_nodes,
+                    &referenced_names,
+                ));
+            }
+            // W006: duplicate implementations (gated by config)
+            if self.enforce_config.duplication {
+                file_violations.extend(violations_economy::check_duplicate_implementation(
+                    file,
+                    &*self.store,
+                    &mut seen_bodies,
+                ));
+            }
+            // W007: oversized files (gated by config)
+            if self.enforce_config.oversized_files {
+                file_violations.extend(violations_economy::check_oversized_file(
+                    file,
+                    &existing_nodes,
+                    self.enforce_config.max_file_lines,
+                ));
+            }
 
             // Fixup: use graph-stored hashes so `keel explain <hash>` works.
             // Some checks (E002, E003, W001, W002) compute hashes freshly, which
@@ -104,6 +135,14 @@ impl EnforcementEngine {
                 {
                     v.hash = node.hash.clone();
                 }
+            }
+
+            // Progressive adoption: E002/E003 on untouched functions become
+            // WARNING (gated by config). Runs before the circuit breaker so
+            // pre-existing debt never accumulates failure counts.
+            if self.enforce_config.progressive {
+                file_violations =
+                    apply_progressive_adoption(file_violations, file, &existing_nodes);
             }
 
             // Downgrade low-confidence violations (dynamic dispatch) to WARNING
@@ -131,24 +170,17 @@ impl EnforcementEngine {
 
             // Track changed hashes and collect node updates for persistence
             for def in &file.definitions {
-                let new_hash = keel_core::hash::compute_hash(
-                    &def.signature,
-                    &def.body_text,
-                    def.docstring.as_deref().unwrap_or(""),
-                );
-                // Also check disambiguated hash (map may have used it for collisions)
-                let new_hash_disambiguated = keel_core::hash::compute_hash_disambiguated(
-                    &def.signature,
-                    &def.body_text,
-                    def.docstring.as_deref().unwrap_or(""),
-                    &file.file_path,
-                );
+                let (new_hash, new_hash_disambiguated) =
+                    crate::violations_util::definition_hashes(def, &file.file_path);
                 if let Some(node) = existing_nodes.iter().find(|n| n.name == def.name) {
                     if node.hash != new_hash && node.hash != new_hash_disambiguated {
                         hashes_changed.push(node.hash.clone());
                         nodes_updated += 1;
-                        // Persist updated hash
+                        // Persist updated hash; record the old one so
+                        // "modified since last map" survives the sync (see
+                        // progressive adoption — a full map re-baselines).
                         let mut updated_node = node.clone();
+                        updated_node.previous_hashes.push(node.hash.clone());
                         updated_node.hash = new_hash;
                         updated_node.signature = def.signature.clone();
                         updated_node.docstring = def.docstring.clone();

--- a/crates/keel-enforce/src/engine_tests.rs
+++ b/crates/keel-enforce/src/engine_tests.rs
@@ -65,3 +65,5 @@ mod e001;
 mod e002_e003;
 #[path = "engine_tests_e004_misc.rs"]
 mod e004_misc;
+#[path = "engine_tests_economy.rs"]
+mod economy;

--- a/crates/keel-enforce/src/engine_tests_circuit_breaker.rs
+++ b/crates/keel-enforce/src/engine_tests_circuit_breaker.rs
@@ -1,23 +1,29 @@
-//! Engine-level circuit breaker reset test: a violation that persists across
-//! several compiles should escalate as before, but once actually resolved its
-//! breaker state must clear rather than staying auto-downgraded forever.
+//! Engine-level circuit breaker reset test: a violation on a session-modified
+//! function persists across compiles and escalates as before, but once
+//! actually resolved its breaker state must clear rather than staying
+//! auto-downgraded forever.
+//!
+//! The function is MODIFIED (stored hash differs from the definition) so that
+//! progressive adoption keeps E002 at ERROR — pre-existing, untouched debt is
+//! progressive adoption's territory (see engine_tests_economy.rs), while the
+//! breaker governs what the agent is actively working on.
 use super::*;
 
 #[test]
 fn test_circuit_breaker_resets_on_resolved_violation() {
     let store = SqliteGraphStore::in_memory().unwrap();
 
-    // Seed the store with a node matching the (still-failing) definition below —
-    // mirrors `keel map` having already registered this function, so the
-    // circuit breaker's hash-based identifier is in scope across compiles.
-    let hash = keel_core::hash::compute_hash("def process(x)", "pass", "Doc for process");
-    let node = make_node(1, &hash, "process", "def process(x)", "app.py");
+    // Seed the store with a STALE hash — the agent has modified this function
+    // this session, so its E002 stays ERROR under progressive adoption.
+    let node = make_node(1, "staleHash000", "process", "def process(x)", "app.py");
     store.insert_node(&node).unwrap();
 
     let mut engine = EnforcementEngine::new(Box::new(store));
 
     let mut bad = make_definition("process", "def process(x)", "pass", "app.py");
     bad.type_hints_present = false;
+    // The hash the store will hold after the first compile syncs it.
+    let synced_hash = keel_core::hash::compute_hash("def process(x)", "pass", "Doc for process");
 
     let make_file = |def: Definition| FileIndex {
         file_path: "app.py".to_string(),
@@ -29,27 +35,39 @@ fn test_circuit_breaker_resets_on_resolved_violation() {
         parse_duration_us: 0,
     };
 
-    // Compile the unresolved violation 3 times in a row — it escalates all
-    // the way to auto-downgrade even though nobody has fixed anything yet.
-    for i in 0..3 {
+    // Compile 1: hash mismatch (stale stored hash) — ERROR, breaker keyed to
+    // the stale hash; the store syncs to `synced_hash` + previous_hashes.
+    let first = engine.compile(&[make_file(bad.clone())]);
+    assert!(
+        first.errors.iter().any(|v| v.code == "E002"),
+        "modified function's E002 must be an ERROR: {:?}",
+        first.errors
+    );
+
+    // Compiles 2-4: hash now stable; previous_hashes marks the function as
+    // session-modified, so E002 stays ERROR and the breaker escalates on the
+    // synced-hash key: fix_hint → wider context → auto-downgrade.
+    for _ in 0..2 {
         let result = engine.compile(&[make_file(bad.clone())]);
         let fired = result
             .errors
             .iter()
             .chain(result.warnings.iter())
             .any(|v| v.code == "E002");
-        assert!(fired, "E002 should fire on attempt {}", i + 1);
+        assert!(fired, "E002 should keep firing while unresolved");
     }
-    assert_eq!(engine.circuit_breaker_failures("E002", &hash, "app.py"), 3);
-    // Third compile should have auto-downgraded it to WARNING.
-    let pre_fix = engine.compile(&[make_file(bad.clone())]);
+    let downgraded = engine.compile(&[make_file(bad.clone())]);
+    assert_eq!(
+        engine.circuit_breaker_failures("E002", &synced_hash, "app.py"),
+        3
+    );
     assert!(
-        pre_fix.warnings.iter().any(|v| v.code == "E002"),
-        "E002 should be auto-downgraded to WARNING after 3 unresolved failures"
+        downgraded.warnings.iter().any(|v| v.code == "E002"),
+        "E002 should be auto-downgraded to WARNING after 3 unresolved failures: {:?}",
+        downgraded.warnings
     );
 
-    // Now actually fix it: add type hints (signature/body/docstring unchanged
-    // so this test isolates the E002 reset from hash-change bookkeeping).
+    // Now actually fix it: add type hints.
     let mut fixed = bad.clone();
     fixed.type_hints_present = true;
     let fixed_result = engine.compile(&[make_file(fixed)]);
@@ -62,7 +80,7 @@ fn test_circuit_breaker_resets_on_resolved_violation() {
         "E002 should not fire once type hints are added"
     );
     assert_eq!(
-        engine.circuit_breaker_failures("E002", &hash, "app.py"),
+        engine.circuit_breaker_failures("E002", &synced_hash, "app.py"),
         0,
         "circuit breaker should reset once the violation is resolved"
     );

--- a/crates/keel-enforce/src/engine_tests_economy.rs
+++ b/crates/keel-enforce/src/engine_tests_economy.rs
@@ -1,0 +1,153 @@
+//! W005/W006/W007 economy checks + progressive adoption, through the engine.
+use super::*;
+use crate::test_fixtures::{definition, file_index, node_for_definition, ECON_BODY};
+
+#[test]
+fn w005_fires_through_compile_and_config_gates_it() {
+    // W005 needs a STORED node (graph evidence); seed one matching the def.
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let def = definition("orphan", "src/a.rs", false);
+    store.insert_node(&node_for_definition(1, &def)).unwrap();
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    let result = engine.compile(&[file_index("src/a.rs", vec![def.clone()])]);
+    assert!(
+        result.warnings.iter().any(|v| v.code == "W005"),
+        "dead private function should warn: {:?}",
+        result.warnings
+    );
+
+    // Gated off via config
+    let store2 = SqliteGraphStore::in_memory().unwrap();
+    store2.insert_node(&node_for_definition(1, &def)).unwrap();
+    let mut config = keel_core::config::KeelConfig::default();
+    config.enforce.dead_code = false;
+    let mut engine2 = EnforcementEngine::with_config(Box::new(store2), &config);
+    let result2 = engine2.compile(&[file_index("src/a.rs", vec![def])]);
+    assert!(!result2.warnings.iter().any(|v| v.code == "W005"));
+}
+
+#[test]
+fn w006_fires_across_files_in_one_compile() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    let result = engine.compile(&[
+        file_index("src/a.rs", vec![definition("calc_a", "src/a.rs", true)]),
+        file_index("src/b.rs", vec![definition("calc_b", "src/b.rs", true)]),
+    ]);
+    let w006: Vec<_> = result
+        .warnings
+        .iter()
+        .filter(|v| v.code == "W006")
+        .collect();
+    assert_eq!(
+        w006.len(),
+        1,
+        "second copy warns once: {:?}",
+        result.warnings
+    );
+    assert!(w006[0].message.contains("calc_a"));
+}
+
+#[test]
+fn w007_fires_through_compile() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    let mut def = definition("big", "src/huge.rs", true);
+    def.line_end = 450;
+    let result = engine.compile(&[file_index("src/huge.rs", vec![def])]);
+    assert!(result.warnings.iter().any(|v| v.code == "W007"));
+}
+
+#[test]
+fn economy_warnings_defer_in_batch_mode() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let def = definition("orphan", "src/a.rs", false);
+    store.insert_node(&node_for_definition(1, &def)).unwrap();
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    engine.batch_start();
+
+    let result = engine.compile(&[file_index("src/a.rs", vec![def])]);
+    assert!(
+        !result.warnings.iter().any(|v| v.code == "W005"),
+        "W005 must defer during batch (scaffolding in progress)"
+    );
+
+    let flushed = engine.batch_end();
+    assert!(
+        flushed.warnings.iter().any(|v| v.code == "W005"),
+        "deferred W005 fires at batch end: {:?}",
+        flushed.warnings
+    );
+}
+
+#[test]
+fn progressive_downgrades_untouched_e003_through_compile() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+
+    // Stored node identical to what the parser will report (untouched),
+    // but PUBLIC and undocumented so E003 fires.
+    let mut def = definition("legacy", "src/old.rs", true);
+    def.body_text = "do_work()".to_string();
+    def.docstring = None;
+    store.insert_node(&node_for_definition(1, &def)).unwrap();
+
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    let result = engine.compile(&[file_index("src/old.rs", vec![def])]);
+
+    assert!(
+        !result.errors.iter().any(|v| v.code == "E003"),
+        "untouched E003 must not be an ERROR: {:?}",
+        result.errors
+    );
+    let downgraded = result
+        .warnings
+        .iter()
+        .find(|v| v.code == "E003")
+        .expect("E003 present as WARNING");
+    assert!(downgraded
+        .fix_hint
+        .as_deref()
+        .unwrap()
+        .contains("pre-existing"));
+}
+
+#[test]
+fn progressive_downgrades_second_same_named_untouched_function() {
+    // Two same-named functions in one file (impl-block style). BOTH are
+    // untouched and undocumented — both E003s must downgrade; first-name-
+    // wins matching would leave the second one as a spurious ERROR.
+    let store = SqliteGraphStore::in_memory().unwrap();
+
+    let mut first = definition("run", "src/old.rs", true);
+    first.body_text = "reader_impl()".to_string();
+    let mut second = definition("run", "src/old.rs", true);
+    second.body_text = "writer_impl()".to_string();
+    second.line_start = 30;
+    second.line_end = 40;
+
+    store.insert_node(&node_for_definition(1, &first)).unwrap();
+    let mut n2 = node_for_definition(2, &second);
+    n2.line_start = 30;
+    n2.line_end = 40;
+    store.insert_node(&n2).unwrap();
+
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    let result = engine.compile(&[file_index("src/old.rs", vec![first, second])]);
+
+    assert!(
+        result.errors.is_empty(),
+        "both untouched same-named functions must downgrade: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.warnings.iter().filter(|v| v.code == "E003").count(),
+        2
+    );
+}
+
+// Keep the shared fixture honest: engine-level W006 depends on this body
+// clearing the duplicate threshold.
+#[test]
+fn econ_body_clears_duplicate_threshold() {
+    assert!(keel_core::hash::normalize_body(ECON_BODY).len() >= 60);
+}

--- a/crates/keel-enforce/src/lib.rs
+++ b/crates/keel-enforce/src/lib.rs
@@ -18,9 +18,13 @@ pub mod engine;
 pub mod fix_generator;
 pub mod hash_diff;
 pub mod naming;
+pub mod progressive;
 pub mod snapshot;
 pub mod suppress;
+#[cfg(test)]
+pub(crate) mod test_fixtures;
 pub mod types;
 pub mod violations;
+pub mod violations_economy;
 pub mod violations_extended;
 pub mod violations_util;

--- a/crates/keel-enforce/src/progressive.rs
+++ b/crates/keel-enforce/src/progressive.rs
@@ -1,0 +1,80 @@
+//! Progressive adoption: annotation/documentation debt on code the current
+//! change did NOT touch reports as WARNING, not ERROR.
+//!
+//! "Untouched" means: the definition's computed hash equals the stored graph
+//! hash AND the node carries no `previous_hashes` — i.e. it has not been
+//! modified since the last full `keel map` (the engine appends the old hash
+//! to `previous_hashes` whenever a compile syncs a changed hash, and a full
+//! map re-baselines by clearing them). The moment a function is edited it
+//! escalates to ERROR and STAYS escalated across compiles until fixed —
+//! touch it, fix it. This implements the documented adoption model
+//! (new/modified code = ERROR, pre-existing = WARNING) without a baseline
+//! file.
+//!
+//! KNOWN LIMITATION: because a full `keel map` re-baselines, escalation
+//! state does not survive a re-map — edited-but-unfixed debt returns to
+//! WARNING afterward. The debt stays VISIBLE (warnings still print and are
+//! counted in stats/telemetry); only its blocking status resets. Making
+//! escalation survive re-maps needs per-node provenance beyond what the
+//! graph stores today.
+
+use keel_core::types::GraphNode;
+use keel_parsers::resolver::FileIndex;
+
+use crate::types::Violation;
+
+/// Codes eligible for the pre-existing downgrade. Structural breakage
+/// (E001/E004/E005) always stays at full severity — a broken caller is a
+/// broken caller regardless of when the function was written.
+const PROGRESSIVE_CODES: &[&str] = &["E002", "E003"];
+
+/// Downgrade E002/E003 ERRORs on untouched functions to WARNING.
+pub fn apply_progressive_adoption(
+    violations: Vec<Violation>,
+    file: &FileIndex,
+    existing_nodes: &[GraphNode],
+) -> Vec<Violation> {
+    violations
+        .into_iter()
+        .map(|mut v| {
+            if v.severity == "ERROR" && PROGRESSIVE_CODES.contains(&v.code.as_str()) {
+                // ANY same-named stored node may be this def's identity (a
+                // file can hold several `run`s across impl blocks) — the
+                // hash comparison, not first-name-wins, decides which one.
+                // Modified-earlier-this-session functions carry their old
+                // hash in previous_hashes; they must NOT decay back to
+                // "pre-existing".
+                let untouched = file
+                    .definitions
+                    .iter()
+                    .find(|d| d.line_start == v.line)
+                    .map(|def| {
+                        existing_nodes
+                            .iter()
+                            .filter(|n| n.name == def.name)
+                            .any(|node| {
+                                node.previous_hashes.is_empty()
+                                    && crate::violations_util::node_hash_matches(
+                                        node,
+                                        def,
+                                        &file.file_path,
+                                    )
+                            })
+                    })
+                    .unwrap_or(false);
+                if untouched {
+                    v.severity = "WARNING".to_string();
+                    v.fix_hint = Some(format!(
+                        "{} (pre-existing — escalates to ERROR when this function is edited)",
+                        v.fix_hint.unwrap_or_default()
+                    ));
+                }
+            }
+            v
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "progressive_tests.rs"]
+mod tests;

--- a/crates/keel-enforce/src/progressive_tests.rs
+++ b/crates/keel-enforce/src/progressive_tests.rs
@@ -1,0 +1,120 @@
+use super::*;
+use keel_core::types::NodeKind;
+use keel_parsers::resolver::Definition;
+
+fn undocumented_def(name: &str, file: &str) -> Definition {
+    Definition {
+        name: name.to_string(),
+        kind: NodeKind::Function,
+        signature: format!("fn {name}()"),
+        file_path: file.to_string(),
+        line_start: 10,
+        line_end: 20,
+        docstring: None,
+        is_public: true,
+        type_hints_present: true,
+        body_text: "do_work()".to_string(),
+    }
+}
+
+fn file_with(def: Definition) -> FileIndex {
+    FileIndex {
+        file_path: def.file_path.clone(),
+        content_hash: 0,
+        definitions: vec![def],
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
+/// A stored node whose hash matches the definition exactly (untouched).
+fn matching_node(def: &Definition) -> GraphNode {
+    GraphNode {
+        id: 1,
+        hash: keel_core::hash::compute_hash(
+            &def.signature,
+            &def.body_text,
+            def.docstring.as_deref().unwrap_or(""),
+        ),
+        kind: NodeKind::Function,
+        name: def.name.clone(),
+        signature: def.signature.clone(),
+        file_path: def.file_path.clone(),
+        line_start: def.line_start,
+        line_end: def.line_end,
+        docstring: def.docstring.clone(),
+        is_public: def.is_public,
+        type_hints_present: def.type_hints_present,
+        has_docstring: def.docstring.is_some(),
+        external_endpoints: vec![],
+        previous_hashes: vec![],
+        module_id: 0,
+        package: None,
+    }
+}
+
+fn e003_violation(def: &Definition) -> Violation {
+    Violation {
+        code: "E003".to_string(),
+        severity: "ERROR".to_string(),
+        category: "missing_docstring".to_string(),
+        message: format!("Public function `{}` has no docstring", def.name),
+        file: def.file_path.clone(),
+        line: def.line_start,
+        hash: String::new(),
+        confidence: 1.0,
+        resolution_tier: "tree-sitter".to_string(),
+        fix_hint: Some("Add a documentation comment".to_string()),
+        suppressed: false,
+        suppress_hint: None,
+        affected: vec![],
+        suggested_module: None,
+        existing: None,
+    }
+}
+
+#[test]
+fn untouched_function_downgrades_to_warning() {
+    let def = undocumented_def("legacy", "src/old.rs");
+    let node = matching_node(&def);
+    let file = file_with(def.clone());
+
+    let out = apply_progressive_adoption(vec![e003_violation(&def)], &file, &[node]);
+    assert_eq!(out[0].severity, "WARNING");
+    assert!(out[0].fix_hint.as_deref().unwrap().contains("pre-existing"));
+}
+
+#[test]
+fn modified_function_stays_error() {
+    let def = undocumented_def("edited", "src/old.rs");
+    let mut node = matching_node(&def);
+    node.hash = "differentHash".to_string(); // stored state differs → touched
+    let file = file_with(def.clone());
+
+    let out = apply_progressive_adoption(vec![e003_violation(&def)], &file, &[node]);
+    assert_eq!(out[0].severity, "ERROR");
+}
+
+#[test]
+fn new_function_stays_error() {
+    let def = undocumented_def("brand_new", "src/new.rs");
+    let file = file_with(def.clone());
+
+    let out = apply_progressive_adoption(vec![e003_violation(&def)], &file, &[]);
+    assert_eq!(out[0].severity, "ERROR");
+}
+
+#[test]
+fn structural_codes_never_downgrade() {
+    let def = undocumented_def("legacy", "src/old.rs");
+    let node = matching_node(&def);
+    let file = file_with(def.clone());
+
+    let mut v = e003_violation(&def);
+    v.code = "E001".to_string();
+    v.category = "broken_caller".to_string();
+    let out = apply_progressive_adoption(vec![v], &file, &[node]);
+    assert_eq!(out[0].severity, "ERROR", "E001 must never be grandfathered");
+}

--- a/crates/keel-enforce/src/test_fixtures.rs
+++ b/crates/keel-enforce/src/test_fixtures.rs
@@ -1,0 +1,95 @@
+//! Shared fixtures for enforcement test modules.
+//!
+//! `ECON_BODY` is load-bearing: it must clear the W006 duplicate-detection
+//! length threshold (`MIN_DUPLICATE_BODY_LEN`), so W005/W006 tests in
+//! different files share this single definition instead of drifting copies.
+
+use keel_core::types::{GraphNode, NodeKind};
+use keel_parsers::resolver::{Definition, FileIndex, Reference, ReferenceKind};
+
+/// A body long enough to clear the W006 duplicate threshold.
+pub(crate) const ECON_BODY: &str =
+    "let total = items.iter().map(|i| i.price * i.qty).sum::<u64>();\n\
+                                    apply_discount(total, customer.tier)";
+
+/// A function definition at lines 10-20 with [`ECON_BODY`].
+pub(crate) fn definition(name: &str, file: &str, is_public: bool) -> Definition {
+    Definition {
+        name: name.to_string(),
+        kind: NodeKind::Function,
+        signature: format!("fn {name}()"),
+        file_path: file.to_string(),
+        line_start: 10,
+        line_end: 20,
+        docstring: None,
+        is_public,
+        type_hints_present: true,
+        body_text: ECON_BODY.to_string(),
+    }
+}
+
+/// A `FileIndex` carrying only definitions.
+pub(crate) fn file_index(file: &str, definitions: Vec<Definition>) -> FileIndex {
+    file_index_with_refs(file, definitions, vec![])
+}
+
+/// A `FileIndex` with definitions and references.
+pub(crate) fn file_index_with_refs(
+    file: &str,
+    definitions: Vec<Definition>,
+    references: Vec<Reference>,
+) -> FileIndex {
+    FileIndex {
+        file_path: file.to_string(),
+        content_hash: 0,
+        definitions,
+        references,
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
+/// A call reference at line 5.
+pub(crate) fn call_ref(name: &str, file: &str) -> Reference {
+    Reference {
+        name: name.to_string(),
+        file_path: file.to_string(),
+        line: 5,
+        kind: ReferenceKind::Call,
+        resolved_to: None,
+    }
+}
+
+/// A stored private-function node at lines 10-20.
+pub(crate) fn function_node(id: u64, hash: &str, name: &str, file: &str) -> GraphNode {
+    GraphNode {
+        id,
+        hash: hash.to_string(),
+        kind: NodeKind::Function,
+        name: name.to_string(),
+        signature: format!("fn {name}()"),
+        file_path: file.to_string(),
+        line_start: 10,
+        line_end: 20,
+        docstring: None,
+        is_public: false,
+        type_hints_present: true,
+        has_docstring: false,
+        external_endpoints: vec![],
+        previous_hashes: vec![],
+        module_id: 0,
+        package: None,
+    }
+}
+
+/// A stored node whose hash matches `def` under `definition_hashes` — i.e.
+/// the graph's record of this exact, untouched definition.
+pub(crate) fn node_for_definition(id: u64, def: &Definition) -> GraphNode {
+    let (hash, _) = crate::violations_util::definition_hashes(def, &def.file_path);
+    let mut node = function_node(id, &hash, &def.name, &def.file_path);
+    node.is_public = def.is_public;
+    node.line_start = def.line_start;
+    node.line_end = def.line_end;
+    node
+}

--- a/crates/keel-enforce/src/violations_economy.rs
+++ b/crates/keel-enforce/src/violations_economy.rs
@@ -1,0 +1,295 @@
+//! Economy checks: keep the codebase lean.
+//!
+//! - W005 `dead_code` — private function with no callers in the graph.
+//! - W006 `duplicate_implementation` — body identical (whitespace-normalized)
+//!   to a function in another file.
+//! - W007 `oversized_file` — file exceeds the configured line budget and grew.
+//!
+//! All three are WARNING severity, deferrable in batch mode, and gated by
+//! `enforce.{dead_code, duplication, oversized_files}` in keel.json.
+
+use std::collections::{HashMap, HashSet};
+
+use keel_core::store::GraphStore;
+use keel_core::types::{EdgeDirection, EdgeKind, GraphNode, NodeKind};
+use keel_parsers::resolver::FileIndex;
+
+use crate::types::Violation;
+use crate::violations_util::{is_bench_file, is_stub_file, is_test_file, node_hash_matches};
+
+/// Bodies shorter than this (whitespace-normalized) are too trivial to call
+/// duplicates — one-line getters and delegations legitimately repeat.
+const MIN_DUPLICATE_BODY_LEN: usize = 60;
+
+// Anything this check wants to match must have been indexed at map time,
+// which gates on the (lower) MIN_INDEXED_BODY_LEN.
+const _: () = assert!(MIN_DUPLICATE_BODY_LEN >= keel_core::hash::MIN_INDEXED_BODY_LEN);
+
+/// Names that are entrypoints or conventionally uncalled — never dead.
+const ENTRYPOINT_NAMES: &[&str] = &["main", "new", "default", "drop", "fmt"];
+
+/// Collect every symbol name referenced anywhere in the compile batch,
+/// including the final segment of qualified references (`obj.method` → both
+/// `obj.method` and `method`). Used to keep W005 from flagging a function
+/// whose caller is being written in the same compile.
+pub fn batch_reference_names(files: &[FileIndex]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for file in files {
+        for r in &file.references {
+            names.insert(r.name.clone());
+            if let Some(last) = r.name.rsplit('.').next() {
+                names.insert(last.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// W005: private functions in this file with zero incoming call edges in the
+/// graph and no reference to them anywhere in the current compile batch.
+///
+/// Precision depends on graph freshness: edges reflect the last `keel map`.
+/// Public functions, entrypoints, tests, stubs, underscore-prefixed names,
+/// and qualified (method-like) names are exempt.
+pub fn check_dead_code(
+    file: &FileIndex,
+    store: &dyn GraphStore,
+    existing_nodes: &[GraphNode],
+    referenced: &HashSet<String>,
+) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    if is_test_file(&file.file_path)
+        || is_stub_file(&file.file_path)
+        || is_bench_file(&file.file_path)
+    {
+        return violations;
+    }
+
+    for def in &file.definitions {
+        if def.kind != NodeKind::Function
+            || def.is_public
+            || def.name.starts_with('_')
+            // `test_*`/`bench_*` cover harness-invoked functions in
+            // co-located #[cfg(test)] modules and criterion benches.
+            || def.name.starts_with("test_")
+            || def.name.starts_with("bench_")
+            || def.name.contains('.')
+            || ENTRYPOINT_NAMES.contains(&def.name.as_str())
+        {
+            continue;
+        }
+        if referenced.contains(&def.name) {
+            continue;
+        }
+
+        // Only STORED functions carry evidence (graph edges). A def with no
+        // stored node has no edge history — and in the mainline hook flow
+        // (one file compiled per edit) a freshly extracted helper's caller
+        // often isn't written yet, so flagging it would misfire constantly.
+        // New dead code is caught on the compile after the next `keel map`.
+        let candidates: Vec<&GraphNode> = existing_nodes
+            .iter()
+            .filter(|n| n.name == def.name)
+            .collect();
+        // Same-named siblings (impl-block methods): pick the node whose hash
+        // matches this def; when nothing matches unambiguously, skip rather
+        // than consult the wrong node's edges.
+        let node = match candidates
+            .iter()
+            .find(|n| node_hash_matches(n, def, &file.file_path))
+        {
+            Some(n) => *n,
+            None if candidates.len() == 1 => candidates[0],
+            None => continue,
+        };
+        let has_callers = store
+            .get_edges(node.id, EdgeDirection::Incoming)
+            .iter()
+            .any(|e| e.kind == EdgeKind::Calls);
+        if has_callers {
+            continue;
+        }
+        let confidence = 0.7;
+        let stored = Some(node);
+
+        violations.push(Violation {
+            code: "W005".to_string(),
+            severity: "WARNING".to_string(),
+            category: "dead_code".to_string(),
+            message: format!("Function `{}` has no callers", def.name),
+            file: file.file_path.clone(),
+            line: def.line_start,
+            hash: stored.map(|n| n.hash.clone()).unwrap_or_default(),
+            confidence,
+            resolution_tier: "heuristic".to_string(),
+            fix_hint: Some(format!(
+                "No callers found for `{}` — delete it, or wire it in and re-run \
+                 `keel map` to refresh call edges",
+                def.name
+            )),
+            suppressed: false,
+            suppress_hint: None,
+            affected: vec![],
+            suggested_module: None,
+            existing: None,
+        });
+    }
+
+    violations
+}
+
+/// W006: function bodies identical (whitespace-normalized) to another
+/// function — either one already in the graph's body index (populated at
+/// `keel map` time) or one seen earlier in this same compile batch.
+///
+/// `seen_bodies` maps body_hash → (file, name, line) across the batch and
+/// must be shared by every file of one compile call.
+pub fn check_duplicate_implementation(
+    file: &FileIndex,
+    store: &dyn GraphStore,
+    seen_bodies: &mut HashMap<String, (String, String, u32)>,
+) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    if is_test_file(&file.file_path) || is_stub_file(&file.file_path) {
+        return violations;
+    }
+
+    for def in &file.definitions {
+        if def.kind != NodeKind::Function {
+            continue;
+        }
+        let normalized = keel_core::hash::normalize_body(&def.body_text);
+        if normalized.len() < MIN_DUPLICATE_BODY_LEN {
+            continue;
+        }
+        let body_hash = keel_core::hash::hash_normalized_body(&normalized);
+
+        // Cross-FILE matches only: identical siblings within one file are
+        // usually a deliberate dispatch pattern (trait impls, format_* fan-out),
+        // while a copy in another file is the drift risk worth flagging.
+        // Prefer a graph-index match; fall back to a batch-local one.
+        let graph_match = store
+            .find_body_matches(&body_hash)
+            .into_iter()
+            .filter(|m| m.file_path != file.file_path)
+            .find(|m| !is_test_file(&m.file_path));
+        let local_match = seen_bodies
+            .get(&body_hash)
+            .filter(|(f, _, _)| f != &file.file_path)
+            .cloned();
+
+        let duplicate = graph_match
+            .map(|m| (m.name, m.file_path, m.line))
+            .or_else(|| local_match.map(|(f, n, l)| (n, f, l)));
+
+        if let Some((other_name, other_file, other_line)) = duplicate {
+            violations.push(Violation {
+                code: "W006".to_string(),
+                severity: "WARNING".to_string(),
+                category: "duplicate_implementation".to_string(),
+                message: format!(
+                    "Body of `{}` is identical to `{}` at {}:{}",
+                    def.name, other_name, other_file, other_line
+                ),
+                file: file.file_path.clone(),
+                line: def.line_start,
+                hash: String::new(),
+                confidence: 0.85,
+                resolution_tier: "heuristic".to_string(),
+                fix_hint: Some(format!(
+                    "Call `{}` ({}:{}) instead of duplicating it, or extract a \
+                     shared helper",
+                    other_name, other_file, other_line
+                )),
+                suppressed: false,
+                suppress_hint: None,
+                affected: vec![],
+                suggested_module: None,
+                existing: None,
+            });
+        }
+
+        seen_bodies
+            .entry(body_hash)
+            .or_insert_with(|| (file.file_path.clone(), def.name.clone(), def.line_start));
+    }
+
+    violations
+}
+
+/// W007: the file's extent exceeds the configured budget AND grew relative
+/// to the stored graph state (shrinking an already-over file stays silent —
+/// reduction is the desired direction).
+///
+/// Both sides of the grew-comparison use the SAME measure — the highest
+/// definition end line. (Stored Module nodes record the whole file's line
+/// count, a different quantity: comparing against it would mask real growth
+/// behind trailing footers/test-mod declarations.) Trailing comments aren't
+/// counted; that under-approximation only makes the check more conservative.
+pub fn check_oversized_file(
+    file: &FileIndex,
+    existing_nodes: &[GraphNode],
+    max_lines: u32,
+) -> Vec<Violation> {
+    if is_test_file(&file.file_path) || is_stub_file(&file.file_path) {
+        return vec![];
+    }
+
+    // Module-kind defs (`mod tests;` items end at EOF) are excluded on BOTH
+    // sides — any asymmetry here manufactures phantom growth.
+    let extent = file
+        .definitions
+        .iter()
+        .filter(|d| d.kind != NodeKind::Module)
+        .map(|d| d.line_end)
+        .max()
+        .unwrap_or(0);
+    if extent <= max_lines {
+        return vec![];
+    }
+
+    let stored_extent = existing_nodes
+        .iter()
+        .filter(|n| n.kind != NodeKind::Module)
+        .map(|n| n.line_end)
+        .max()
+        .unwrap_or(0);
+    if extent <= stored_extent {
+        return vec![];
+    }
+
+    let module_hash = existing_nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Module)
+        .map(|n| n.hash.clone())
+        .unwrap_or_default();
+
+    vec![Violation {
+        code: "W007".to_string(),
+        severity: "WARNING".to_string(),
+        category: "oversized_file".to_string(),
+        message: format!(
+            "File is ~{} lines (budget {}) and growing",
+            extent, max_lines
+        ),
+        file: file.file_path.clone(),
+        line: 1,
+        hash: module_hash,
+        confidence: 0.8,
+        resolution_tier: "heuristic".to_string(),
+        fix_hint: Some(format!(
+            "Split {} into focused modules under {} lines — run `keel analyze {}` \
+             for split suggestions, or delete what's no longer needed",
+            file.file_path, max_lines, file.file_path
+        )),
+        suppressed: false,
+        suppress_hint: None,
+        affected: vec![],
+        suggested_module: None,
+        existing: None,
+    }]
+}
+
+#[cfg(test)]
+#[path = "violations_economy_tests.rs"]
+mod tests;

--- a/crates/keel-enforce/src/violations_economy_tests.rs
+++ b/crates/keel-enforce/src/violations_economy_tests.rs
@@ -1,0 +1,316 @@
+use std::collections::{HashMap, HashSet};
+
+use super::*;
+use crate::test_fixtures::{
+    call_ref, definition, file_index, file_index_with_refs, function_node, node_for_definition,
+    ECON_BODY,
+};
+use keel_core::sqlite::SqliteGraphStore;
+use keel_core::types::{EdgeChange, GraphEdge};
+
+fn calls_edge(id: u64, src: u64, tgt: u64) -> EdgeChange {
+    EdgeChange::Add(GraphEdge {
+        id,
+        source_id: src,
+        target_id: tgt,
+        kind: EdgeKind::Calls,
+        file_path: "src/b.rs".to_string(),
+        line: 3,
+        confidence: 1.0,
+    })
+}
+
+// --- W005 dead_code ---
+
+#[test]
+fn w005_silent_for_unstored_function() {
+    // A def with no stored node has no edge history — and in the one-file-
+    // per-edit hook flow its caller often isn't written yet. Never flag it;
+    // it's caught on the compile after the next `keel map`.
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let file = file_index("src/a.rs", vec![definition("orphan", "src/a.rs", false)]);
+    assert!(check_dead_code(&file, &store, &[], &HashSet::new()).is_empty());
+}
+
+#[test]
+fn w005_fires_on_stored_function_with_zero_edges() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let def = definition("orphan", "src/a.rs", false);
+    store.insert_node(&node_for_definition(1, &def)).unwrap();
+    let file = file_index("src/a.rs", vec![def]);
+    let stored = store.get_nodes_in_file("src/a.rs");
+
+    let v = check_dead_code(&file, &store, &stored, &HashSet::new());
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].code, "W005");
+    assert_eq!(v[0].severity, "WARNING");
+    assert!((v[0].confidence - 0.7).abs() < f64::EPSILON);
+    assert_eq!(v[0].hash, stored[0].hash, "stored hash is reported");
+}
+
+#[test]
+fn w005_silent_for_public_entrypoint_underscore_and_qualified() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let defs = vec![
+        definition("exported", "src/a.rs", true),
+        definition("main", "src/a.rs", false),
+        definition("_intentional", "src/a.rs", false),
+        definition("Widget.render", "src/a.rs", false),
+    ];
+    let mut stored = Vec::new();
+    for (i, def) in defs.iter().enumerate() {
+        let node = node_for_definition(i as u64 + 1, def);
+        store.insert_node(&node).unwrap();
+        stored.push(node);
+    }
+    let file = file_index("src/a.rs", defs);
+    assert!(check_dead_code(&file, &store, &stored, &HashSet::new()).is_empty());
+}
+
+#[test]
+fn w005_silent_when_referenced_in_batch() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let def = definition("helper", "src/a.rs", false);
+    store.insert_node(&node_for_definition(1, &def)).unwrap();
+    let stored = store.get_nodes_in_file("src/a.rs");
+    let file = file_index("src/a.rs", vec![def]);
+
+    let mut referenced = HashSet::new();
+    referenced.insert("helper".to_string());
+    assert!(check_dead_code(&file, &store, &stored, &referenced).is_empty());
+}
+
+#[test]
+fn w005_respects_graph_call_edges() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let def = definition("used", "src/a.rs", false);
+    store.insert_node(&node_for_definition(1, &def)).unwrap();
+    store
+        .insert_node(&function_node(2, "callerHash000", "caller", "src/b.rs"))
+        .unwrap();
+    store.update_edges(vec![calls_edge(1, 2, 1)]).unwrap();
+
+    let stored = store.get_nodes_in_file("src/a.rs");
+    let file = file_index("src/a.rs", vec![def]);
+    assert!(check_dead_code(&file, &store, &stored, &HashSet::new()).is_empty());
+}
+
+#[test]
+fn w005_same_named_siblings_use_hash_to_pick_the_right_node() {
+    // Two impl blocks in one file, both defining `parse`. Foo::parse is
+    // called; Bar::parse is dead. Hash matching must consult the right
+    // node's edges — first-name-wins would either miss the dead one or flag
+    // the live one depending on declaration order.
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let live_def = definition("parse", "src/a.rs", false);
+    let mut dead_def = definition("parse", "src/a.rs", false);
+    dead_def.body_text = format!("{ECON_BODY}\nextra_dead_variant()");
+    dead_def.line_start = 30;
+    dead_def.line_end = 40;
+
+    let live_node = node_for_definition(1, &live_def);
+    let mut dead_node = node_for_definition(2, &dead_def);
+    dead_node.line_start = 30;
+    dead_node.line_end = 40;
+    store.insert_node(&live_node).unwrap();
+    store.insert_node(&dead_node).unwrap();
+    store
+        .insert_node(&function_node(3, "callerHash000", "caller", "src/b.rs"))
+        .unwrap();
+    store.update_edges(vec![calls_edge(1, 3, 1)]).unwrap();
+
+    let stored = store.get_nodes_in_file("src/a.rs");
+    let file = file_index("src/a.rs", vec![live_def, dead_def.clone()]);
+    let v = check_dead_code(&file, &store, &stored, &HashSet::new());
+    assert_eq!(v.len(), 1, "only the dead sibling fires: {v:?}");
+    assert_eq!(v[0].line, dead_def.line_start);
+    assert_eq!(
+        v[0].hash, dead_node.hash,
+        "the DEAD node's hash is reported"
+    );
+}
+
+#[test]
+fn w005_silent_in_test_and_bench_files() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    for path in ["tests/util.rs", "benches/perf.rs"] {
+        let def = definition("fixture", path, false);
+        let node = node_for_definition(1, &def);
+        let file = file_index(path, vec![def]);
+        assert!(
+            check_dead_code(&file, &store, &[node], &HashSet::new()).is_empty(),
+            "{path} must be exempt"
+        );
+    }
+}
+
+// --- W006 duplicate_implementation ---
+
+#[test]
+fn w006_fires_on_batch_local_duplicate() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let mut seen = HashMap::new();
+    let file_a = file_index("src/a.rs", vec![definition("calc_a", "src/a.rs", true)]);
+    let file_b = file_index("src/b.rs", vec![definition("calc_b", "src/b.rs", true)]);
+
+    assert!(check_duplicate_implementation(&file_a, &store, &mut seen).is_empty());
+    let v = check_duplicate_implementation(&file_b, &store, &mut seen);
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].code, "W006");
+    assert!(v[0].message.contains("calc_a"));
+    assert!(v[0].fix_hint.as_deref().unwrap().contains("src/a.rs"));
+}
+
+#[test]
+fn w006_ignores_whitespace_differences() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let mut seen = HashMap::new();
+    let mut reformatted = definition("calc_b", "src/b.rs", true);
+    reformatted.body_text = ECON_BODY.replace(' ', "  ").replace('\n', "\n\n");
+
+    let file_a = file_index("src/a.rs", vec![definition("calc_a", "src/a.rs", true)]);
+    let file_b = file_index("src/b.rs", vec![reformatted]);
+    assert!(check_duplicate_implementation(&file_a, &store, &mut seen).is_empty());
+    assert_eq!(
+        check_duplicate_implementation(&file_b, &store, &mut seen).len(),
+        1
+    );
+}
+
+#[test]
+fn w006_silent_for_trivial_bodies() {
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let mut seen = HashMap::new();
+    let mut a = definition("get_a", "src/a.rs", true);
+    a.body_text = "self.a".to_string();
+    let mut b = definition("get_b", "src/b.rs", true);
+    b.body_text = "self.a".to_string();
+
+    assert!(
+        check_duplicate_implementation(&file_index("src/a.rs", vec![a]), &store, &mut seen)
+            .is_empty()
+    );
+    assert!(
+        check_duplicate_implementation(&file_index("src/b.rs", vec![b]), &store, &mut seen)
+            .is_empty()
+    );
+}
+
+#[test]
+fn w006_silent_for_same_file_siblings() {
+    // Identical siblings within ONE file are usually a deliberate dispatch
+    // pattern (trait impls, format_* fan-out) — only cross-file copies warn.
+    let store = SqliteGraphStore::in_memory().unwrap();
+    let mut seen = HashMap::new();
+    let mut second = definition("calc_b", "src/a.rs", true);
+    second.line_start = 30;
+    let file = file_index(
+        "src/a.rs",
+        vec![definition("calc_a", "src/a.rs", true), second],
+    );
+    assert!(check_duplicate_implementation(&file, &store, &mut seen).is_empty());
+}
+
+#[test]
+fn w006_fires_on_graph_index_match() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![keel_core::types::BodyIndexEntry {
+            body_hash: keel_core::hash::compute_body_hash(ECON_BODY),
+            node_hash: "origHash0000".to_string(),
+            name: "original".to_string(),
+            file_path: "src/orig.rs".to_string(),
+            line: 42,
+        }])
+        .unwrap();
+
+    let file = file_index(
+        "src/copy.rs",
+        vec![definition("copied", "src/copy.rs", true)],
+    );
+    let mut seen = HashMap::new();
+    let v = check_duplicate_implementation(&file, &store, &mut seen);
+    assert_eq!(v.len(), 1);
+    assert!(v[0].message.contains("original"));
+    assert!(v[0].message.contains("src/orig.rs"));
+}
+
+#[test]
+fn w006_ignores_graph_matches_from_own_file() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    store
+        .replace_body_index(vec![keel_core::types::BodyIndexEntry {
+            body_hash: keel_core::hash::compute_body_hash(ECON_BODY),
+            node_hash: "selfHash0000".to_string(),
+            name: "calc".to_string(),
+            file_path: "src/a.rs".to_string(),
+            line: 10,
+        }])
+        .unwrap();
+
+    let file = file_index("src/a.rs", vec![definition("calc", "src/a.rs", true)]);
+    let mut seen = HashMap::new();
+    assert!(check_duplicate_implementation(&file, &store, &mut seen).is_empty());
+}
+
+// --- W007 oversized_file ---
+
+#[test]
+fn w007_fires_when_over_budget_and_growing() {
+    let mut def = definition("big", "src/huge.rs", true);
+    def.line_end = 450;
+    let file = file_index("src/huge.rs", vec![def]);
+    let v = check_oversized_file(&file, &[], 400);
+    assert_eq!(v.len(), 1);
+    assert_eq!(v[0].code, "W007");
+    assert!(v[0].message.contains("450"));
+}
+
+#[test]
+fn w007_silent_when_shrinking_even_if_still_over() {
+    let mut def = definition("big", "src/huge.rs", true);
+    def.line_end = 450;
+    let file = file_index("src/huge.rs", vec![def]);
+    let mut stored = function_node(1, "bigHash00000", "big", "src/huge.rs");
+    stored.line_end = 500; // was bigger before this change
+    assert!(check_oversized_file(&file, &[stored], 400).is_empty());
+}
+
+#[test]
+fn w007_module_node_line_count_does_not_mask_growth() {
+    // The stored Module node records the WHOLE file's line count (defs +
+    // trailing footer). Comparing the def-derived extent against it would
+    // hide genuine growth whenever the footer is longer than the increment.
+    let mut def = definition("appended", "src/huge.rs", true);
+    def.line_end = 597; // last def after the agent appended a function
+
+    let mut module = function_node(1, "modHash00000", "src/huge.rs", "src/huge.rs");
+    module.kind = NodeKind::Module;
+    module.line_end = 600; // true file length at map time (footer included)
+    let mut old_def = function_node(2, "defHash00000", "appended", "src/huge.rs");
+    old_def.line_end = 585; // last def at map time
+
+    let file = file_index("src/huge.rs", vec![def]);
+    let v = check_oversized_file(&file, &[module, old_def], 400);
+    assert_eq!(v.len(), 1, "growth 585 -> 597 must fire despite module=600");
+}
+
+#[test]
+fn w007_silent_under_budget() {
+    let file = file_index("src/small.rs", vec![definition("f", "src/small.rs", true)]);
+    assert!(check_oversized_file(&file, &[], 400).is_empty());
+}
+
+// --- batch_reference_names ---
+
+#[test]
+fn batch_reference_names_include_qualified_suffix() {
+    let file = file_index_with_refs(
+        "src/a.rs",
+        vec![],
+        vec![call_ref("widget.render", "src/a.rs")],
+    );
+    let names = batch_reference_names(&[file]);
+    assert!(names.contains("widget.render"));
+    assert!(names.contains("render"));
+}

--- a/crates/keel-enforce/src/violations_extended.rs
+++ b/crates/keel-enforce/src/violations_extended.rs
@@ -5,7 +5,9 @@ use keel_core::types::{EdgeDirection, EdgeKind, NodeKind};
 use keel_parsers::resolver::FileIndex;
 
 use crate::types::{AffectedNode, Violation};
-use crate::violations_util::{count_call_args, count_params, extract_prefix, is_test_file};
+use crate::violations_util::{
+    count_call_args, count_params, extract_prefix, is_test_file, normalize_signature,
+};
 
 /// Check E004: function_removed — a function was removed but callers still exist.
 /// Compares existing nodes in the store against current file definitions.
@@ -194,7 +196,26 @@ pub fn check_placement(file: &FileIndex, store: &dyn GraphStore) -> Vec<Violatio
     violations
 }
 
-/// Check W002: duplicate_name — same function name in multiple modules.
+/// Check W002: duplicate_name — same function name AND same (whitespace-
+/// normalized) signature exists in **exactly one** other module.
+///
+/// Matching by name alone over-fires on idiomatic namespacing — e.g. every
+/// CLI subcommand module defining its own `run(args) -> Result<()>` isn't a
+/// naming collision, it's the pattern working as intended. Requiring the
+/// signature to match too keeps the warning for genuine accidental
+/// duplicates (same name, same shape) while staying silent on same-name/
+/// different-signature functions that just happen to share a verb.
+///
+/// Name+signature equality alone still isn't enough, though: trait/interface
+/// conformance produces the exact same signature at every impl site by
+/// construction (e.g. four `LanguageResolver` impls all defining an
+/// identically-shaped `parse_file`, or every type's `Default`/`fmt` impl).
+/// That's a deliberate pattern, not a collision. The discriminator is count:
+/// an accidental duplicate comes in a **pair** (one copy-pasted from the
+/// other); three or more identical sites is conformance to a shared
+/// contract. So this only fires when exactly one other matching site
+/// exists — 2 total copies. 3+ copies stay silent here (W006's body-hash
+/// check still catches genuine multi-copy duplication independent of name).
 /// Uses indexed SQL query instead of triple-nested loop. O(F) not O(F*M*N).
 pub fn check_duplicate_names(file: &FileIndex, store: &dyn GraphStore) -> Vec<Violation> {
     let mut violations = Vec::new();
@@ -211,44 +232,55 @@ pub fn check_duplicate_names(file: &FileIndex, store: &dyn GraphStore) -> Vec<Vi
 
         // Single SQL query per function — finds same-named functions elsewhere
         let duplicates = store.find_nodes_by_name(&def.name, "function", &file.file_path);
-        for node in &duplicates {
+        let normalized_def_sig = normalize_signature(&def.signature);
+        let same_shape: Vec<_> = duplicates
+            .iter()
             // Skip test files in results
-            if is_test_file(&node.file_path) {
-                continue;
-            }
-            violations.push(Violation {
-                code: "W002".to_string(),
-                severity: "WARNING".to_string(),
-                category: "duplicate_name".to_string(),
-                message: format!(
-                    "Function `{}` also exists in `{}`",
-                    def.name, node.file_path
-                ),
-                file: file.file_path.clone(),
-                line: def.line_start,
-                hash: keel_core::hash::compute_hash(
-                    &def.signature,
-                    &def.body_text,
-                    def.docstring.as_deref().unwrap_or(""),
-                ),
-                confidence: 0.7,
-                resolution_tier: "heuristic".to_string(),
-                fix_hint: Some(format!(
-                    "Rename one of the `{}` functions to avoid ambiguity",
-                    def.name
-                )),
-                suppressed: false,
-                suppress_hint: None,
-                affected: vec![],
-                suggested_module: None,
-                existing: Some(crate::types::ExistingNode {
-                    hash: node.hash.clone(),
-                    file: node.file_path.clone(),
-                    line: node.line_start,
-                }),
-            });
-            break; // One per definition
+            .filter(|node| !is_test_file(&node.file_path))
+            // Same name but a different shape is idiomatic namespacing, not
+            // a duplicate — only consider sites where the signature matches.
+            .filter(|node| normalize_signature(&node.signature) == normalized_def_sig)
+            .collect();
+
+        // Exactly one other matching site = suspect pair. Zero = no
+        // collision. Two or more = a shared contract (trait/interface
+        // conformance) — deliberate, not accidental — stay silent.
+        if same_shape.len() != 1 {
+            continue;
         }
+        let node = same_shape[0];
+
+        violations.push(Violation {
+            code: "W002".to_string(),
+            severity: "WARNING".to_string(),
+            category: "duplicate_name".to_string(),
+            message: format!(
+                "Function `{}` also exists in `{}`",
+                def.name, node.file_path
+            ),
+            file: file.file_path.clone(),
+            line: def.line_start,
+            hash: keel_core::hash::compute_hash(
+                &def.signature,
+                &def.body_text,
+                def.docstring.as_deref().unwrap_or(""),
+            ),
+            confidence: 0.7,
+            resolution_tier: "heuristic".to_string(),
+            fix_hint: Some(format!(
+                "Rename `{}` here or its duplicate in `{}` to avoid ambiguity",
+                def.name, node.file_path
+            )),
+            suppressed: false,
+            suppress_hint: None,
+            affected: vec![],
+            suggested_module: None,
+            existing: Some(crate::types::ExistingNode {
+                hash: node.hash.clone(),
+                file: node.file_path.clone(),
+                line: node.line_start,
+            }),
+        });
     }
 
     violations

--- a/crates/keel-enforce/src/violations_util.rs
+++ b/crates/keel-enforce/src/violations_util.rs
@@ -1,3 +1,36 @@
+/// Compute the (plain, disambiguated) hash pair for a definition — the two
+/// identities `keel map` may have stored for it (map salts with the file
+/// path on collision). Single source of truth for "does this def match its
+/// stored node", shared by the engine's hash sync and progressive adoption.
+pub fn definition_hashes(
+    def: &keel_parsers::resolver::Definition,
+    file_path: &str,
+) -> (String, String) {
+    let doc = def.docstring.as_deref().unwrap_or("");
+    (
+        keel_core::hash::compute_hash(&def.signature, &def.body_text, doc),
+        keel_core::hash::compute_hash_disambiguated(&def.signature, &def.body_text, doc, file_path),
+    )
+}
+
+/// Whether a stored node's hash matches the definition under either of the
+/// two identities from [`definition_hashes`].
+pub fn node_hash_matches(
+    node: &keel_core::types::GraphNode,
+    def: &keel_parsers::resolver::Definition,
+    file_path: &str,
+) -> bool {
+    let (hash, hash_d) = definition_hashes(def, file_path);
+    node.hash == hash || node.hash == hash_d
+}
+
+/// Check if a file is a benchmark file — harness-invoked, like tests, so
+/// dead-code analysis doesn't apply.
+pub fn is_bench_file(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.starts_with("benches/") || normalized.contains("/benches/")
+}
+
 /// Check if a file is a declaration/stub file: signature-only by definition,
 /// so docstring and body-level checks don't apply (`.pyi` stubs, `.d.ts`
 /// declarations).
@@ -10,7 +43,7 @@ pub fn is_stub_file(path: &str) -> bool {
 
 /// Check if a file path is a test file by language convention.
 /// Patterns: *_test.go, test_*.py, *_test.py, *.test.ts, *.spec.ts,
-/// *.test.js, *.spec.js, *_test.rs, tests.rs
+/// *.test.js, *.spec.js, *_test.rs, *_tests.rs, tests.rs
 pub fn is_test_file(path: &str) -> bool {
     let normalized = path.replace('\\', "/");
 
@@ -42,8 +75,11 @@ pub fn is_test_file(path: &str) -> bool {
     if basename.contains(".test.") || basename.contains(".spec.") {
         return true;
     }
-    // Rust: *_test.rs or tests.rs
-    if basename.ends_with("_test.rs") || basename == "tests.rs" {
+    // Rust: *_test.rs, *_tests.rs (plural — this repo's own `#[path =
+    // "..._tests.rs"] mod tests;` convention), or exactly tests.rs.
+    // Suffix match, not substring: "utils_tests.rs" matches, "contests.rs"
+    // does not (no underscore before "tests.rs").
+    if basename.ends_with("_test.rs") || basename.ends_with("_tests.rs") || basename == "tests.rs" {
         return true;
     }
     false
@@ -94,20 +130,74 @@ pub fn normalize_signature(sig: &str) -> String {
     sig.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
-/// Extract a name prefix (e.g., "handle" from "handleRequest").
-pub fn extract_prefix(name: &str) -> String {
-    // Split on camelCase or snake_case boundary
-    if let Some(pos) = name.find('_') {
-        return name[..pos].to_string();
+/// Split `name` into (start, end) byte ranges for each "word" segment, using
+/// snake_case underscores if present, else camelCase upper-case transitions.
+fn segment_ranges(name: &str) -> Vec<(usize, usize)> {
+    if name.contains('_') {
+        let mut ranges = Vec::new();
+        let mut start = 0;
+        for (i, c) in name.char_indices() {
+            if c == '_' {
+                if i > start {
+                    ranges.push((start, i));
+                }
+                start = i + c.len_utf8();
+            }
+        }
+        if start < name.len() {
+            ranges.push((start, name.len()));
+        }
+        return ranges;
     }
-    // camelCase: find first lowercase->uppercase transition
-    let chars: Vec<char> = name.chars().collect();
-    for i in 1..chars.len() {
-        if chars[i].is_uppercase() {
-            return chars[..i].iter().collect();
+
+    // camelCase, with acronym runs treated as one segment: a new segment
+    // starts at an uppercase char only when the previous char is lowercase
+    // (a plain lower->upper transition, e.g. "parse"|"Header"), or when the
+    // previous char is ALSO uppercase but the next char is lowercase (this
+    // is the last capital of a run, which kicks off the next word, e.g. the
+    // second "H" in "HTTPHeader" starts "Header" while "HTTP" stays whole).
+    // Standard camel tokenization: "parseHTTPHeader" -> parse/HTTP/Header,
+    // "toJSONString" -> to/JSON/String, "readIOBuffer" -> read/IO/Buffer.
+    // Without this, consecutive capitals would shatter into one-char
+    // segments ("parseHTTPHeader" -> p-a-r-s-e-H-T-T-P... over-matching
+    // even worse than a single leading segment).
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    let indices: Vec<(usize, char)> = name.char_indices().collect();
+    for i in 1..indices.len() {
+        let (idx, ch) = indices[i];
+        if !ch.is_uppercase() {
+            continue;
+        }
+        let prev_is_upper = indices[i - 1].1.is_uppercase();
+        let next_is_lower = indices.get(i + 1).is_some_and(|&(_, c)| c.is_lowercase());
+        if !prev_is_upper || next_is_lower {
+            ranges.push((start, idx));
+            start = idx;
         }
     }
-    String::new()
+    if !indices.is_empty() {
+        ranges.push((start, name.len()));
+    }
+    ranges
+}
+
+/// Extract a multi-segment name prefix (e.g. "get_user" from "get_user_name",
+/// "getUser" from "getUserName") used to suggest a placement module.
+///
+/// Only a prefix spanning **at least two** segments is meaningful enough to
+/// suggest a placement — a single leading segment (e.g. "make" from
+/// "make_relative") over-matches wildly, since unrelated functions across
+/// the whole codebase commonly share a first word. Names with fewer than
+/// three total segments can't produce a two-segment prefix while leaving a
+/// remainder (a single word, or a two-word name where the "prefix" would be
+/// the entire name), so they return an empty prefix and never fire W001.
+pub fn extract_prefix(name: &str) -> String {
+    let ranges = segment_ranges(name);
+    if ranges.len() < 3 {
+        return String::new();
+    }
+    name[ranges[0].0..ranges[1].1].to_string()
 }
 
 #[cfg(test)]
@@ -165,8 +255,6 @@ mod tests {
 
     #[test]
     fn test_extract_prefix() {
-        assert_eq!(extract_prefix("handleRequest"), "handle");
-        assert_eq!(extract_prefix("process_order"), "process");
         assert_eq!(extract_prefix("x"), "");
     }
 
@@ -176,8 +264,51 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_prefix_single_segment_names_never_match() {
+        // Common short verbs/names — never enough segments to produce a prefix.
+        assert_eq!(extract_prefix("run"), "");
+        assert_eq!(extract_prefix("main"), "");
+        assert_eq!(extract_prefix("default"), "");
+    }
+
+    #[test]
     fn test_extract_prefix_snake_case_multi() {
-        assert_eq!(extract_prefix("get_user_name"), "get");
+        // 3+ segments: prefix is the first TWO segments, not just the first.
+        assert_eq!(extract_prefix("get_user_name"), "get_user");
+        assert_eq!(extract_prefix("get_user_profile_data"), "get_user");
+    }
+
+    #[test]
+    fn test_extract_prefix_camel_case_multi() {
+        assert_eq!(extract_prefix("getUserName"), "getUser");
+        // Only two segments — no match, same rule as snake_case.
+        assert_eq!(extract_prefix("handleRequest"), "");
+    }
+
+    #[test]
+    fn test_extract_prefix_acronym_runs_stay_one_segment() {
+        // Consecutive capitals are one segment (the acronym), not one
+        // segment per letter — otherwise "parseHTTPHeader" would shatter
+        // into p/a/r/s/e/H/T/T/P/... and over-match worse than the old
+        // single-segment behavior. Standard camel tokenization: the run
+        // splits right before its last capital when that capital is
+        // followed by a lowercase letter (it belongs to the next word).
+        assert_eq!(extract_prefix("parseHTTPHeader"), "parseHTTP");
+        assert_eq!(extract_prefix("toJSONString"), "toJSON");
+        assert_eq!(extract_prefix("readIOBuffer"), "readIO");
+
+        // All-caps name: one giant acronym run = a single segment = no
+        // multi-segment prefix possible.
+        assert_eq!(extract_prefix("HTTP"), "");
+    }
+
+    #[test]
+    fn test_extract_prefix_two_segment_names_never_match() {
+        // Regression guard: these used to extract a single-segment prefix
+        // ("make", "process") that over-matched wildly. Now they need a
+        // third segment to leave room for a genuine 2-segment prefix.
+        assert_eq!(extract_prefix("make_relative"), "");
+        assert_eq!(extract_prefix("process_order"), "");
     }
 
     #[test]
@@ -259,6 +390,15 @@ mod tests {
         assert!(is_test_file("src/handler_test.rs"));
         assert!(is_test_file("src/tests.rs"));
         assert!(!is_test_file("src/handler.rs"));
+
+        // Rust: plural `*_tests.rs` — this repo's own
+        // `#[path = "..._tests.rs"] mod tests;` convention.
+        assert!(is_test_file("crates/keel-core/src/sqlite_tests.rs"));
+        assert!(is_test_file("engine_tests.rs"));
+        assert!(is_test_file("utils_tests.rs"));
+        // Suffix match, not substring: no underscore before "tests.rs".
+        assert!(!is_test_file("contests.rs"));
+        assert!(!is_test_file("src/testing_utils.rs")); // not a test file
 
         // Directory-based detection
         assert!(is_test_file("src/tests/helpers.py"));

--- a/tests/cli/test_exit_codes.rs
+++ b/tests/cli/test_exit_codes.rs
@@ -55,9 +55,13 @@ fn init_and_map(files: &[(&str, &str)]) -> TempDir {
 #[test]
 /// Exit code 0 on successful compile with no violations.
 fn test_exit_code_0_clean_compile() {
+    // The fixture must be GENUINELY clean (docstring included): under
+    // progressive adoption, debt on untouched code is a WARNING, which
+    // exits 0 with warning output — only a zero-violation compile promises
+    // the empty-stdout contract this test asserts.
     let dir = init_and_map(&[(
         "src/clean.ts",
-        "export function clean(x: number): number { return x; }\n",
+        "/** Returns the input unchanged. */\nexport function clean(x: number): number { return x; }\n",
     )]);
     let keel = keel_bin();
 

--- a/tests/enforcement/test_duplicate_detection.rs
+++ b/tests/enforcement/test_duplicate_detection.rs
@@ -64,6 +64,18 @@ fn make_func_def(name: &str, file: &str, line: u32) -> Definition {
     }
 }
 
+fn make_file(file: &str, defs: Vec<Definition>) -> FileIndex {
+    FileIndex {
+        file_path: file.to_string(),
+        content_hash: 0,
+        definitions: defs,
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
 #[test]
 fn test_w002_duplicate_name_across_modules() {
     let mut store = in_memory_store();
@@ -87,15 +99,7 @@ fn test_w002_duplicate_name_across_modules() {
 
     // Check from module_a's perspective
     let def = make_func_def("process", "module_a.py", 1);
-    let file = FileIndex {
-        file_path: "module_a.py".to_string(),
-        content_hash: 0,
-        definitions: vec![def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("module_a.py", vec![def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert_eq!(violations.len(), 1);
@@ -117,15 +121,7 @@ fn test_w002_no_duplicate_no_warning() {
         .unwrap();
 
     let def = make_func_def("different_name", "module_b.py", 1);
-    let file = FileIndex {
-        file_path: "module_b.py".to_string(),
-        content_hash: 0,
-        definitions: vec![def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("module_b.py", vec![def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert!(violations.is_empty());
@@ -149,15 +145,7 @@ fn test_w002_severity_is_warning() {
         .unwrap();
 
     let def = make_func_def("dupe", "a.py", 1);
-    let file = FileIndex {
-        file_path: "a.py".to_string(),
-        content_hash: 0,
-        definitions: vec![def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("a.py", vec![def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert!(!violations.is_empty());
@@ -182,15 +170,7 @@ fn test_w002_includes_all_locations() {
         .unwrap();
 
     let def = make_func_def("process", "a.py", 5);
-    let file = FileIndex {
-        file_path: "a.py".to_string(),
-        content_hash: 0,
-        definitions: vec![def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("a.py", vec![def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert_eq!(violations.len(), 1);
@@ -220,15 +200,7 @@ fn test_w002_test_files_excluded() {
 
     // Check from test file — test files are skipped entirely
     let def = make_func_def("process", "test_main.py", 1);
-    let file = FileIndex {
-        file_path: "test_main.py".to_string(),
-        content_hash: 0,
-        definitions: vec![def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("test_main.py", vec![def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert!(violations.is_empty());
@@ -252,20 +224,120 @@ fn test_w002_fix_hint_present() {
         .unwrap();
 
     let def = make_func_def("handler", "a.py", 1);
-    let file = FileIndex {
-        file_path: "a.py".to_string(),
-        content_hash: 0,
-        definitions: vec![def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("a.py", vec![def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert_eq!(violations.len(), 1);
     assert!(violations[0].fix_hint.is_some());
     assert!(violations[0].fix_hint.as_ref().unwrap().contains("handler"));
+}
+
+#[test]
+fn test_w002_same_name_different_signature_no_warning() {
+    // Idiomatic namespacing: every module defines its own `run()` with a
+    // different shape (e.g. one CLI subcommand's `run(args)` vs another's
+    // `run(args, ctx)`). Same name, different signature -> not a duplicate,
+    // must stay silent.
+    let mut store = in_memory_store();
+
+    let mod_a = make_module_node(1, "cmd_build.py");
+    let fn_a = make_func_node(2, "run", "cmd_build.py", 1); // "def run()"
+    let mod_b = make_module_node(3, "cmd_deploy.py");
+    let mut fn_b = make_func_node(4, "run", "cmd_deploy.py", 1);
+    fn_b.signature = "def run(env)".to_string(); // different shape
+    store
+        .update_nodes(vec![
+            NodeChange::Add(mod_a),
+            NodeChange::Add(fn_a),
+            NodeChange::Add(mod_b),
+            NodeChange::Add(fn_b),
+        ])
+        .unwrap();
+
+    let def = make_func_def("run", "cmd_build.py", 1); // "def run()", matches fn_a's shape
+    let file = make_file("cmd_build.py", vec![def]);
+
+    let violations = check_duplicate_names(&file, &store);
+    assert!(
+        violations.is_empty(),
+        "same name with a different signature elsewhere should not fire W002"
+    );
+}
+
+#[test]
+fn test_w002_whitespace_normalized_signature_still_fires() {
+    // The signature comparison should ignore pure reformatting (rustfmt/
+    // prettier-style wrapping), same as E001's normalize_signature reuse.
+    let mut store = in_memory_store();
+
+    let mod_a = make_module_node(1, "a.py");
+    let mut fn_a = make_func_node(2, "process", "a.py", 1);
+    fn_a.signature = "fn process(x: i32, y: i32) -> bool".to_string();
+    let mod_b = make_module_node(3, "b.py");
+    let mut fn_b = make_func_node(4, "process", "b.py", 1);
+    fn_b.signature = "fn process(\n    x: i32,\n    y: i32\n) -> bool".to_string();
+    store
+        .update_nodes(vec![
+            NodeChange::Add(mod_a),
+            NodeChange::Add(fn_a),
+            NodeChange::Add(mod_b),
+            NodeChange::Add(fn_b),
+        ])
+        .unwrap();
+
+    let mut def = make_func_def("process", "a.py", 1);
+    def.signature = "fn process(x: i32, y: i32) -> bool".to_string();
+    let file = make_file("a.py", vec![def]);
+
+    let violations = check_duplicate_names(&file, &store);
+    assert_eq!(
+        violations.len(),
+        1,
+        "whitespace-only signature differences should still count as duplicates"
+    );
+}
+
+#[test]
+fn test_w002_trait_style_trio_silent() {
+    // Three identically-named, identically-shaped sites (e.g. every
+    // LanguageResolver impl defining its own `parse_file`, or every type's
+    // `Default`/`fmt` impl) is conformance to a shared contract, not an
+    // accidental duplicate -- the pair-only rule must stay silent here even
+    // though name+signature both match everywhere.
+    let mut store = in_memory_store();
+
+    // Each impl has a distinct body in practice (different language, same
+    // shared signature), so give each node a distinct hash -- otherwise all
+    // three would collide on the same `hash` (its UNIQUE key in the store)
+    // and the later inserts would silently overwrite the earlier ones.
+    let mod_a = make_module_node(1, "ts_resolver.py");
+    let mut fn_a = make_func_node(2, "parse_file", "ts_resolver.py", 1);
+    fn_a.hash = "hashts0000a".to_string();
+    let mod_b = make_module_node(3, "py_resolver.py");
+    let mut fn_b = make_func_node(4, "parse_file", "py_resolver.py", 1);
+    fn_b.hash = "hashpy0000b".to_string();
+    let mod_c = make_module_node(5, "go_resolver.py");
+    let mut fn_c = make_func_node(6, "parse_file", "go_resolver.py", 1);
+    fn_c.hash = "hashgo0000c".to_string();
+    store
+        .update_nodes(vec![
+            NodeChange::Add(mod_a),
+            NodeChange::Add(fn_a),
+            NodeChange::Add(mod_b),
+            NodeChange::Add(fn_b),
+            NodeChange::Add(mod_c),
+            NodeChange::Add(fn_c),
+        ])
+        .unwrap();
+
+    let def = make_func_def("parse_file", "ts_resolver.py", 1);
+    let file = make_file("ts_resolver.py", vec![def]);
+
+    let violations = check_duplicate_names(&file, &store);
+    assert!(
+        violations.is_empty(),
+        "3+ identically-shaped sites is trait/interface conformance, not a duplicate"
+    );
 }
 
 #[test]
@@ -309,15 +381,7 @@ fn test_w002_class_not_reported() {
         type_hints_present: true,
         body_text: "pass".to_string(),
     };
-    let file = FileIndex {
-        file_path: "b.py".to_string(),
-        content_hash: 0,
-        definitions: vec![class_def],
-        references: vec![],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
+    let file = make_file("b.py", vec![class_def]);
 
     let violations = check_duplicate_names(&file, &store);
     assert!(violations.is_empty());

--- a/tests/enforcement/test_placement.rs
+++ b/tests/enforcement/test_placement.rs
@@ -5,11 +5,28 @@
 // focus on verifiable behaviors through the public API.
 use keel_core::hash::compute_hash;
 use keel_core::store::GraphStore;
-use keel_core::types::{GraphNode, NodeChange, NodeKind};
+use keel_core::types::{GraphNode, ModuleProfile, NodeChange, NodeKind};
 use keel_enforce::violations::check_placement;
 use keel_parsers::resolver::{Definition, FileIndex};
 
 use crate::common::in_memory_store;
+
+/// A module profile whose only prefix is `prefix`, at the given module_id/path.
+fn make_profile(module_id: u64, path: &str, prefix: &str) -> ModuleProfile {
+    ModuleProfile {
+        module_id,
+        path: path.to_string(),
+        function_count: 1,
+        class_count: 0,
+        line_count: 10,
+        function_name_prefixes: vec![prefix.to_string()],
+        primary_types: vec![],
+        import_sources: vec![],
+        export_targets: vec![],
+        external_endpoint_count: 0,
+        responsibility_keywords: vec![],
+    }
+}
 
 fn make_module_node(id: u64, file: &str) -> GraphNode {
     GraphNode {
@@ -168,4 +185,69 @@ fn test_w001_violation_structure() {
     assert_eq!(v.severity, "WARNING");
     assert!(v.suggested_module.is_some());
     assert!(v.confidence > 0.0 && v.confidence <= 1.0);
+}
+
+#[test]
+fn test_w001_multi_segment_prefix_fires() {
+    // "get_user_name" -> prefix "get_user" (2 segments) matches a module
+    // profile keyed on "get_user" -> should fire.
+    let mut store = in_memory_store();
+    let mod_node = make_module_node(1, "user_service.py");
+    store.update_nodes(vec![NodeChange::Add(mod_node)]).unwrap();
+    store
+        .upsert_module_profiles(vec![make_profile(1, "user_service.py", "get_user")])
+        .unwrap();
+
+    let def = make_func_def("get_user_name", "utils.py");
+    let file = make_file("utils.py", vec![def]);
+
+    let violations = check_placement(&file, &store);
+    assert_eq!(violations.len(), 1);
+    assert_eq!(
+        violations[0].suggested_module,
+        Some("user_service.py".to_string())
+    );
+}
+
+#[test]
+fn test_w001_single_segment_names_never_fire() {
+    // "run"/"main"/"default" are single-word names — extract_prefix always
+    // returns empty for them, so W001 must never fire regardless of what
+    // module profiles exist.
+    let mut store = in_memory_store();
+    let mod_node = make_module_node(1, "main_service.py");
+    store.update_nodes(vec![NodeChange::Add(mod_node)]).unwrap();
+    store
+        .upsert_module_profiles(vec![make_profile(1, "main_service.py", "run")])
+        .unwrap();
+
+    for name in ["run", "main", "default"] {
+        let def = make_func_def(name, "utils.py");
+        let file = make_file("utils.py", vec![def]);
+        let violations = check_placement(&file, &store);
+        assert!(
+            violations.is_empty(),
+            "`{name}` should never fire W001 (single-segment name)"
+        );
+    }
+}
+
+#[test]
+fn test_w001_two_segment_name_no_longer_over_matches() {
+    // Regression guard for the de-noise fix: "make_relative" used to extract
+    // just "make" and over-match against any module whose profile happened
+    // to list "make" as a prefix. A two-segment name has no room to produce
+    // a genuine 2-segment prefix (it would just be the whole name), so this
+    // must no longer fire even though a matching "make" profile exists.
+    let mut store = in_memory_store();
+    let mod_node = make_module_node(1, "path_utils.py");
+    store.update_nodes(vec![NodeChange::Add(mod_node)]).unwrap();
+    store
+        .upsert_module_profiles(vec![make_profile(1, "path_utils.py", "make")])
+        .unwrap();
+
+    let def = make_func_def("make_relative", "utils.py");
+    let file = make_file("utils.py", vec![def]);
+    let violations = check_placement(&file, &store);
+    assert!(violations.is_empty());
 }

--- a/tests/graph/test_schema_migration.rs
+++ b/tests/graph/test_schema_migration.rs
@@ -5,7 +5,7 @@ use keel_core::sqlite::SqliteGraphStore;
 #[test]
 /// Opening an existing database should report its current schema version.
 fn test_schema_version_tracking() {
-    // GIVEN a fresh in-memory SQLite database (auto-creates schema v2)
+    // GIVEN a fresh in-memory SQLite database (auto-creates the current schema)
     let store = SqliteGraphStore::in_memory().expect("in-memory store");
 
     // WHEN schema_version is queried
@@ -13,8 +13,8 @@ fn test_schema_version_tracking() {
         .schema_version()
         .expect("schema_version should succeed");
 
-    // THEN it reports version 2
-    assert_eq!(version, 4, "initial schema version should be 4");
+    // THEN it reports the current version
+    assert_eq!(version, 5, "initial schema version should be 5");
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn test_v1_to_v2_migration() {
 
     // THEN schema version is now 2
     let version = store.schema_version().unwrap();
-    assert_eq!(version, 4, "v1 database should be migrated to v4");
+    assert_eq!(version, 5, "v1 database should be migrated to v5");
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn test_migrated_data_accessible() {
     let store = SqliteGraphStore::open(db_str).unwrap();
 
     // THEN the migrated data is queryable
-    assert_eq!(store.schema_version().unwrap(), 4);
+    assert_eq!(store.schema_version().unwrap(), 5);
 
     // Drop store so we can open raw connection
     drop(store);
@@ -168,7 +168,7 @@ fn test_future_schema_version_not_rejected() {
     // First create a valid database
     {
         let store = SqliteGraphStore::open(db_str).unwrap();
-        assert_eq!(store.schema_version().unwrap(), 4);
+        assert_eq!(store.schema_version().unwrap(), 5);
     }
 
     // Manually set schema_version to 99 via raw SQL
@@ -202,7 +202,7 @@ fn test_migration_idempotency() {
     {
         let store = SqliteGraphStore::open(db_path_str).expect("first open");
         let v = store.schema_version().expect("version check");
-        assert_eq!(v, 4, "first open should be v4");
+        assert_eq!(v, 5, "first open should be v5");
     }
 
     // AND the store is opened again at the same path
@@ -210,7 +210,7 @@ fn test_migration_idempotency() {
         let store = SqliteGraphStore::open(db_path_str).expect("second open");
         let v = store.schema_version().expect("version check");
 
-        // THEN the schema version is still 2 (no corruption or double-migration)
-        assert_eq!(v, 4, "second open should still be v4");
+        // THEN the schema version is unchanged (no corruption or double-migration)
+        assert_eq!(v, 5, "second open should still be v5");
     }
 }

--- a/tests/graph/test_sqlite_advanced.rs
+++ b/tests/graph/test_sqlite_advanced.rs
@@ -293,7 +293,7 @@ fn test_sqlite_auto_create_schema() {
     assert!(db_path.exists(), "db file should have been created");
 
     let version = store.schema_version().unwrap();
-    assert_eq!(version, 4, "schema version should be 4");
+    assert_eq!(version, 5, "schema version should be 5");
 
     // Verify we can perform basic operations on the fresh schema
     let modules = store.get_all_modules();

--- a/tests/integration/test_init_to_compile.rs
+++ b/tests/integration/test_init_to_compile.rs
@@ -37,11 +37,15 @@ fn setup_ts_project() -> TempDir {
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
 
-    // Private functions (no `export`) avoid E002/E003 checks on public API
+    // A GENUINELY clean fixture: the exported function is documented and
+    // typed (E002/E003), every private function has a caller (W005), and
+    // `main` is entrypoint-exempt. "Clean compile" tests depend on this
+    // producing zero errors AND zero warnings.
     fs::write(
         src.join("math.ts"),
-        r#"function add(a: number, b: number): number {
-    return a + b;
+        r#"/** Adds two numbers. */
+export function add(a: number, b: number): number {
+    return multiply(a, 1) + b;
 }
 
 function multiply(a: number, b: number): number {
@@ -57,7 +61,7 @@ function multiply(a: number, b: number): number {
     return "Hello " + name;
 }
 
-function run(): void {
+function main(): void {
     greet("world");
 }
 "#,

--- a/tests/schemas/compile_output.schema.json
+++ b/tests/schemas/compile_output.schema.json
@@ -71,6 +71,9 @@
             "arity_mismatch",
             "placement",
             "duplicate_name",
+            "dead_code",
+            "duplicate_implementation",
+            "oversized_file",
             "suppressed"
           ],
           "description": "Violation category"


### PR DESCRIPTION
## Summary

Implements **economy enforcement** — the "clean, simple, not bloated" half of keel's mandate. Today keel enforces *discipline* (annotations, docstrings, placement); this PR adds enforcement of *economy*: nothing dead, nothing duplicated, nothing oversized, and pre-existing debt reported without blocking. Built on the graph keel already maintains — the one asset no linter has at generation time.

Extends the frozen contract **additively** (sanctioned): constitution Article 6 gains three codes, the compile schema's category enum gains three entries. Existing codes, severities, and exit codes unchanged. No version bump.

### New checks (all WARNING, batch-deferrable, config-gated)

**W005 `dead_code`** — private function with zero incoming call edges and no reference anywhere in the compile batch. Evidence-based: only fires on functions the graph knows (mapped); brand-new defs are never flagged (in the one-file-per-edit hook flow the caller often isn't written yet — dead code is caught on the compile after the next map). Same-named siblings (impl-block methods) disambiguated by hash. Exempt: public/exported, tests, benches, stubs, entrypoints, `test_`/`bench_`/`_` prefixes.

**W006 `duplicate_implementation`** — whitespace-normalized body hash matches a function in **another file** (same-file identical siblings are idiomatic dispatch patterns — trait impls, `format_*` fan-outs). Backed by a new `body_index` table (schema v4→v5) rebuilt at map time with a composite `(node_hash, file_path, line)` PK, plus batch-local matching for copies written in one compile. Includes a stale-DDL guard so pre-fix v5 databases self-heal.

**W007 `oversized_file`** — definition extent exceeds `enforce.max_file_lines` (default 400, keel's own convention) **and grew** relative to the stored graph. Shrinking an already-over file stays silent — reduction is the desired direction. Both sides of the comparison exclude Module-kind entries (dogfood-found: `mod tests;` footers ending at EOF manufactured phantom growth).

### Progressive adoption — documented for two releases, now real

E002/E003 on functions **unmodified since the last full map** report as WARNING; modified or new functions stay ERROR — touch it, fix it. Escalation survives across compiles via `previous_hashes` (which `update_nodes` now actually persists — it was a known dead path). Known, documented limitation: a full `keel map` re-baselines; demoted debt stays *visible* as WARNING, only its blocking status resets.

### De-noising existing checks (driven by dogfooding on keel itself)

- **W002**: fires only on name + normalized-signature matches occurring as an isolated **pair** — 3+ identical sites are trait/interface conformance, not copy-paste (`default` ×20, `parse_file` ×4 across the four resolvers were all noise).
- **W001**: requires a multi-segment prefix with proper acronym tokenization (`parseHTTPHeader` → parse/HTTP/Header); single-segment names (`run`, `make`) never fire.
- `is_test_file` learns the `*_tests.rs` convention (this repo's own `#[path]` pattern — previously 600+ test functions were classified as production code); map hotspots exclude test files.

### Dogfood numbers (full-repo compile of keel itself)

| stage | warnings | errors |
|---|---|---|
| first run, untuned | 862 | 0 |
| final | **78** | **0** |

The 78 survivors are dominated by real findings: W006's first run surfaced `clean_compile` **triplicated** across the three output formatters, a duplicated `cs`/`make_call_site` pair in tier3, and identical resolver stubs — genuine pre-existing duplication. Known residual FP classes (documented): W005 on callback-registered functions the graph can't see (VS Code extension style), W002 on trait-default+single-impl pairs.

### Config

New `enforce` fields, all default-on: `progressive`, `dead_code`, `duplication`, `oversized_files`, `max_file_lines` (400).

### Review process

Two review rounds with adversarial verification: 7 correctness findings (all fixed and re-verified — including the W007 measurement asymmetry, W005's mainline-workflow misfire, name-only lookup bugs in both new checks, and an unsound PK) and 6 simplification findings (all applied — single-normalize API, compile-time threshold assert, shared fixtures, helper consolidation). Every fix mutation-tested or covered by a regression test that fails without it.

## Testing

- `cargo fmt --check` / `clippy --workspace -D warnings` / `cargo test --workspace` (0 failures) / `RUSTDOCFLAGS=-D warnings cargo doc` — all green
- ~60 new tests: per-check units, engine-level integration (gating, batch deferral, progressive downgrade paths, same-named siblings), sqlite v5 migration + stale-DDL self-heal (mutation-tested), body-hash roundtrips
- Dogfooded end-to-end on keel's own 250k-line tree at every tuning step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiHTastzDCBANn87cn434B
