### PR TITLE
Fix #48: non-fatal persist-time hash collisions, git SHA in --version, 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to keel will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-07-21
+
+First release since v0.4.2 picking up 75 commits of main (#48): Svelte/SvelteKit
+parsing and resolution, test-context enforcement exemptions (#38/#39), parser
+attribution fixes for same-named members (`de05056`), MCP protocol compliance,
+economy enforcement (W005–W007), and the deep-clean backlog (#19–#46).
+
+### Fixed
+- Hash collisions at persist time are non-fatal (#48): a colliding node is
+  re-salted with a file-path ordinal instead of aborting the whole compile
+  with `failed to persist node updates`.
+
+### Changed
+- `keel --version` now embeds the git short SHA (e.g. `0.4.3 (abc123def)`), so
+  an unreleased dev build can no longer masquerade as a released version (#48).
+
+[0.4.3]: https://github.com/FryrAI/Keel/compare/v0.4.2...v0.4.3
+
 ## [0.3.0] - 2026-02-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "keel-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "keel-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "keel-enforce"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ignore",
  "keel-core",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "keel-output"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "keel-enforce",
  "serde_json",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "keel-parsers"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ignore",
  "keel-core",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "keel-server"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "axum",
  "keel-core",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "keel-tests"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "axum",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license-file = "LICENSE"
 rust-version = "1.75"
@@ -76,19 +76,19 @@ protobuf = "3"
 ignore = "0.4"
 
 # Internal crates — path for local dev, version for crates.io publish
-keel-core = { path = "crates/keel-core", version = "0.4.2" }
-keel-parsers = { path = "crates/keel-parsers", version = "0.4.2" }
-keel-enforce = { path = "crates/keel-enforce", version = "0.4.2" }
-keel-cli = { path = "crates/keel-cli", version = "0.4.2" }
-keel-server = { path = "crates/keel-server", version = "0.4.2" }
-keel-output = { path = "crates/keel-output", version = "0.4.2" }
+keel-core = { path = "crates/keel-core", version = "0.4.3" }
+keel-parsers = { path = "crates/keel-parsers", version = "0.4.3" }
+keel-enforce = { path = "crates/keel-enforce", version = "0.4.3" }
+keel-cli = { path = "crates/keel-cli", version = "0.4.3" }
+keel-server = { path = "crates/keel-server", version = "0.4.3" }
+keel-output = { path = "crates/keel-output", version = "0.4.3" }
 
 [dependencies]
-keel-core = { path = "crates/keel-core", version = "0.4.2" }
-keel-parsers = { path = "crates/keel-parsers", version = "0.4.2" }
-keel-enforce = { path = "crates/keel-enforce", version = "0.4.2" }
-keel-output = { path = "crates/keel-output", version = "0.4.2" }
-keel-server = { path = "crates/keel-server", version = "0.4.2" }
+keel-core = { path = "crates/keel-core", version = "0.4.3" }
+keel-parsers = { path = "crates/keel-parsers", version = "0.4.3" }
+keel-enforce = { path = "crates/keel-enforce", version = "0.4.3" }
+keel-output = { path = "crates/keel-output", version = "0.4.3" }
+keel-server = { path = "crates/keel-server", version = "0.4.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/keel-cli/build.rs
+++ b/crates/keel-cli/build.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+/// Run `git` with `args` and return trimmed stdout on success.
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Embed the git short SHA into the version string (`0.4.3 (abc123def)`) so an
+/// unreleased dev build can never masquerade as a released version (#48).
+/// Falls back to the plain crate version when there is no git context
+/// (e.g. a crates.io build).
+fn main() {
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let full = match git(&["rev-parse", "--short=9", "HEAD"]) {
+        Some(sha) => format!("{version} ({sha})"),
+        None => version,
+    };
+    println!("cargo:rustc-env=KEEL_VERSION_FULL={full}");
+
+    // Re-embed when HEAD moves; skip missing ref files (packed refs).
+    if let Some(dir) = git(&["rev-parse", "--absolute-git-dir"]) {
+        println!("cargo:rerun-if-changed={dir}/HEAD");
+        if let Some(head_ref) = git(&["symbolic-ref", "-q", "HEAD"]) {
+            let ref_path = format!("{dir}/{head_ref}");
+            if std::path::Path::new(&ref_path).exists() {
+                println!("cargo:rerun-if-changed={ref_path}");
+            }
+        }
+    }
+}

--- a/crates/keel-cli/build.rs
+++ b/crates/keel-cli/build.rs
@@ -13,20 +13,23 @@ fn git(args: &[&str]) -> Option<String> {
 /// Falls back to the plain crate version when there is no git context
 /// (e.g. a crates.io build).
 fn main() {
-    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let version = env!("CARGO_PKG_VERSION");
     let full = match git(&["rev-parse", "--short=9", "HEAD"]) {
         Some(sha) => format!("{version} ({sha})"),
-        None => version,
+        None => version.to_string(),
     };
     println!("cargo:rustc-env=KEEL_VERSION_FULL={full}");
 
-    // Re-embed when HEAD moves; skip missing ref files (packed refs).
+    // Re-embed when HEAD moves. The reflog is appended on every commit and
+    // checkout even when refs are packed; loose paths are skipped if missing
+    // so cargo doesn't treat them as perpetually changed.
     if let Some(dir) = git(&["rev-parse", "--absolute-git-dir"]) {
-        println!("cargo:rerun-if-changed={dir}/HEAD");
-        if let Some(head_ref) = git(&["symbolic-ref", "-q", "HEAD"]) {
-            let ref_path = format!("{dir}/{head_ref}");
-            if std::path::Path::new(&ref_path).exists() {
-                println!("cargo:rerun-if-changed={ref_path}");
+        for path in [format!("{dir}/HEAD"), format!("{dir}/logs/HEAD")]
+            .into_iter()
+            .chain(git(&["symbolic-ref", "-q", "HEAD"]).map(|head_ref| format!("{dir}/{head_ref}")))
+        {
+            if std::path::Path::new(&path).exists() {
+                println!("cargo:rerun-if-changed={path}");
             }
         }
     }

--- a/crates/keel-cli/src/cli_args.rs
+++ b/crates/keel-cli/src/cli_args.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(
     name = "keel",
-    version,
+    version = env!("KEEL_VERSION_FULL"),
     about = "Structural code enforcement for LLM agents"
 )]
 pub(crate) struct Cli {

--- a/crates/keel-core/src/hash.rs
+++ b/crates/keel-core/src/hash.rs
@@ -43,6 +43,23 @@ pub fn compute_hash(canonical_signature: &str, body_normalized: &str, docstring:
     base62_encode(hash_value)
 }
 
+/// Cap on the disambiguation-ordinal walk shared by every layer that assigns
+/// salted identities (engine re-baseline, persist-time fallback).
+pub const MAX_DISAMBIGUATION_ORDINAL: u32 = 64;
+
+/// Salt for the Nth disambiguation candidate of a definition in `file_path`:
+/// ordinal 1 is the plain file path (the identity `keel map` assigns to the
+/// common two-def case — several parse-layer call sites inline it directly),
+/// 2+ append `#<ordinal>`. Walks that go past ordinal 1 must derive their
+/// candidates here so the engine and persist layers stay in lockstep.
+pub fn disambiguation_salt(file_path: &str, ordinal: u32) -> String {
+    if ordinal == 1 {
+        file_path.to_string()
+    } else {
+        format!("{file_path}#{ordinal}")
+    }
+}
+
 /// Compute a disambiguated hash when a collision is detected.
 /// Appends the file path to the input to create a unique hash.
 pub fn compute_hash_disambiguated(

--- a/crates/keel-core/src/sqlite_helpers.rs
+++ b/crates/keel-core/src/sqlite_helpers.rs
@@ -358,6 +358,49 @@ impl SqliteGraphStore {
         Ok(())
     }
 
+    /// Last-resort persist-time collision fallback (#48): find a free
+    /// file-path-salted hash for `node` instead of aborting the whole persist.
+    ///
+    /// The normalized body is not available here, so this cannot reproduce the
+    /// parse layer's disambiguated identity — later compiles converge on it
+    /// through the normal re-baseline path. Walks ordinals like the engine's
+    /// salt loop; only if all 64 candidates are taken does the original
+    /// `HashCollision` surface as an error.
+    pub(crate) fn persist_disambiguated_hash(
+        tx: &rusqlite::Transaction<'_>,
+        node: &GraphNode,
+        existing_name: &str,
+    ) -> Result<String, GraphError> {
+        const MAX_ORDINAL: u32 = 64;
+        let doc = node.docstring.as_deref().unwrap_or("");
+        for ordinal in 1..=MAX_ORDINAL {
+            let salt = if ordinal == 1 {
+                node.file_path.clone()
+            } else {
+                format!("{}#{}", node.file_path, ordinal)
+            };
+            let candidate =
+                crate::hash::compute_hash_disambiguated(&node.signature, "", doc, &salt);
+            let taken: i64 = tx.query_row(
+                "SELECT COUNT(*) FROM nodes WHERE hash = ?1",
+                params![candidate],
+                |row| row.get(0),
+            )?;
+            if taken == 0 {
+                eprintln!(
+                    "[keel] warning: hash collision for {} between '{}' and '{}' — auto-disambiguated to {}",
+                    node.hash, existing_name, node.name, candidate
+                );
+                return Ok(candidate);
+            }
+        }
+        Err(GraphError::HashCollision {
+            hash: node.hash.clone(),
+            existing: existing_name.to_string(),
+            new_fn: node.name.clone(),
+        })
+    }
+
     /// Update an existing node by ID, preserving the old hash in previous_hashes.
     pub fn update_node_in_db(&self, node: &GraphNode) -> Result<(), GraphError> {
         // Store old hash as previous hash

--- a/crates/keel-core/src/sqlite_helpers.rs
+++ b/crates/keel-core/src/sqlite_helpers.rs
@@ -363,30 +363,25 @@ impl SqliteGraphStore {
     ///
     /// The normalized body is not available here, so this cannot reproduce the
     /// parse layer's disambiguated identity — later compiles converge on it
-    /// through the normal re-baseline path. Walks ordinals like the engine's
-    /// salt loop; only if all 64 candidates are taken does the original
-    /// `HashCollision` surface as an error.
+    /// through the normal re-baseline path. Walks the shared salt protocol
+    /// ([`crate::hash::disambiguation_salt`]); only if every candidate is
+    /// taken does the original `HashCollision` surface as an error.
     pub(crate) fn persist_disambiguated_hash(
         tx: &rusqlite::Transaction<'_>,
         node: &GraphNode,
         existing_name: &str,
     ) -> Result<String, GraphError> {
-        const MAX_ORDINAL: u32 = 64;
         let doc = node.docstring.as_deref().unwrap_or("");
-        for ordinal in 1..=MAX_ORDINAL {
-            let salt = if ordinal == 1 {
-                node.file_path.clone()
-            } else {
-                format!("{}#{}", node.file_path, ordinal)
-            };
+        for ordinal in 1..=crate::hash::MAX_DISAMBIGUATION_ORDINAL {
+            let salt = crate::hash::disambiguation_salt(&node.file_path, ordinal);
             let candidate =
                 crate::hash::compute_hash_disambiguated(&node.signature, "", doc, &salt);
-            let taken: i64 = tx.query_row(
-                "SELECT COUNT(*) FROM nodes WHERE hash = ?1",
+            let taken: bool = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM nodes WHERE hash = ?1)",
                 params![candidate],
                 |row| row.get(0),
             )?;
-            if taken == 0 {
+            if !taken {
                 eprintln!(
                     "[keel] warning: hash collision for {} between '{}' and '{}' — auto-disambiguated to {}",
                     node.hash, existing_name, node.name, candidate

--- a/crates/keel-core/src/sqlite_queries.rs
+++ b/crates/keel-core/src/sqlite_queries.rs
@@ -141,7 +141,7 @@ impl GraphStore for SqliteGraphStore {
         let tx = self.conn.transaction()?;
         for change in changes {
             match change {
-                NodeChange::Add(node) => {
+                NodeChange::Add(mut node) => {
                     // Check for hash collision (different function, same hash)
                     let existing: Option<String> = tx
                         .query_row(
@@ -152,11 +152,11 @@ impl GraphStore for SqliteGraphStore {
                         .ok();
                     if let Some(existing_name) = existing {
                         if existing_name != node.name {
-                            return Err(GraphError::HashCollision {
-                                hash: node.hash.clone(),
-                                existing: existing_name,
-                                new_fn: node.name.clone(),
-                            });
+                            // Non-fatal (#48): re-salt this node instead of
+                            // aborting — one colliding pair must not take down
+                            // the compile gate for an entire repo.
+                            node.hash =
+                                Self::persist_disambiguated_hash(&tx, &node, &existing_name)?;
                         }
                     }
                     // UPSERT to handle re-map without cascade-deleting related rows
@@ -209,7 +209,7 @@ impl GraphStore for SqliteGraphStore {
                         Self::append_previous_hashes(&tx, stored_id, &node.previous_hashes)?;
                     }
                 }
-                NodeChange::Update(node) => {
+                NodeChange::Update(mut node) => {
                     // Check for hash collision (different node, same hash)
                     let existing: Option<(u64, String)> = tx
                         .query_row(
@@ -220,11 +220,9 @@ impl GraphStore for SqliteGraphStore {
                         .ok();
                     if let Some((existing_id, existing_name)) = existing {
                         if existing_id != node.id {
-                            return Err(GraphError::HashCollision {
-                                hash: node.hash.clone(),
-                                existing: existing_name,
-                                new_fn: node.name.clone(),
-                            });
+                            // Non-fatal (#48): same fallback as the Add arm.
+                            node.hash =
+                                Self::persist_disambiguated_hash(&tx, &node, &existing_name)?;
                         }
                     }
                     tx.execute(

--- a/crates/keel-core/src/sqlite_tests.rs
+++ b/crates/keel-core/src/sqlite_tests.rs
@@ -274,15 +274,19 @@ fn test_circuit_breaker_empty_roundtrip() {
 }
 
 #[test]
-fn test_hash_collision_different_names_still_errors() {
+fn test_hash_collision_different_names_auto_disambiguates() {
     let mut store = SqliteGraphStore::in_memory().unwrap();
     let node1 = test_node(1, "collision_hash", "func_a");
     store.update_nodes(vec![NodeChange::Add(node1)]).unwrap();
     let node2 = test_node(2, "collision_hash", "func_b");
-    assert!(
-        store.update_nodes(vec![NodeChange::Add(node2)]).is_err(),
-        "Hash collision between different functions should still error"
-    );
+    store
+        .update_nodes(vec![NodeChange::Add(node2)])
+        .expect("collision must not abort the persist (#48)");
+    // Original keeps its hash; the collider is stored under a salted one.
+    assert_eq!(store.get_node("collision_hash").unwrap().name, "func_a");
+    let salted = store.get_node_by_id(2).expect("collider persisted");
+    assert_eq!(salted.name, "func_b");
+    assert_ne!(salted.hash, "collision_hash");
 }
 
 #[test]

--- a/crates/keel-enforce/src/engine.rs
+++ b/crates/keel-enforce/src/engine.rs
@@ -11,10 +11,7 @@ use crate::types::{CompileInfo, CompileResult, Violation};
 use crate::violations;
 use crate::violations_economy;
 
-/// Safety bound on the re-baseline disambiguation walk (see `compile`). Far
-/// above any real file's same-named-definition count; it exists only so a
-/// pathological store state cannot spin the loop forever.
-const MAX_DISAMBIGUATION_ORDINAL: u32 = 64;
+use keel_core::hash::MAX_DISAMBIGUATION_ORDINAL;
 
 /// Core enforcement engine. Owns a GraphStore and orchestrates validation.
 pub struct EnforcementEngine {
@@ -226,8 +223,9 @@ impl EnforcementEngine {
             // `fn is_available(&self) -> bool` impls in `python/ty.rs`) to the
             // same node: that node then received two conflicting hash updates
             // while its sibling was orphaned, and the second update tried to
-            // claim the hash the sibling legitimately owns — aborting the whole
-            // persist with a HashCollision.
+            // claim the hash the sibling legitimately owns — which used to
+            // abort the whole persist with a HashCollision (update_nodes now
+            // re-salts non-fatally, but the identity would still be wrong).
             // Bind in TWO passes, not greedily per def. A single greedy pass
             // that prefers an exact (name, line) match but falls back to the
             // first unclaimed same-named node mis-pairs when two same-named defs
@@ -279,10 +277,10 @@ impl EnforcementEngine {
                         // the plain file-path salt, so the common two-def case
                         // still lands on the identity `keel map` would assign;
                         // 2+ only appear once a third same-named def exists.
-                        // A single non-iterating fallback left every same-file
-                        // duplicate sharing ONE disambiguated hash, and
-                        // `update_nodes` then aborted the whole persist with a
-                        // HashCollision.
+                        // Assigning stable, body-aware identities here keeps the
+                        // persist layer's body-blind collision fallback
+                        // (`persist_disambiguated_hash`, which would churn on
+                        // the next compile) a rare last resort.
                         let mut candidate = Some(new_hash.clone());
                         let mut ordinal = 0u32;
                         while let Some(ref h) = candidate {
@@ -300,15 +298,14 @@ impl EnforcementEngine {
                             } else if ordinal <= MAX_DISAMBIGUATION_ORDINAL {
                                 Some(crate::violations_util::definition_hash_salted(
                                     def,
-                                    &format!("{}#{}", file.file_path, ordinal),
+                                    &keel_core::hash::disambiguation_salt(&file.file_path, ordinal),
                                 ))
                             } else {
                                 // Exhausted (needs 65+ identical same-named
                                 // defs in one file): skip this node's
-                                // re-baseline rather than persist a hash that
-                                // was never verified free — an unverified write
-                                // is exactly the HashCollision full-persist
-                                // abort this loop exists to prevent.
+                                // re-baseline rather than hand the persist
+                                // layer an unverified hash it would have to
+                                // re-salt blindly.
                                 None
                             };
                         }

--- a/crates/keel-enforce/src/engine_tests_e004_misc.rs
+++ b/crates/keel-enforce/src/engine_tests_e004_misc.rs
@@ -207,8 +207,9 @@ fn test_config_defaults_enable_all() {
 /// Two identical `fn default() -> Self { Self::new() }` in DIFFERENT files
 /// normalize to the same content hash. `keel map` stores the second one under
 /// its file-salted (disambiguated) identity; the engine's re-baseline pass must
-/// do the same, or it hands both nodes one hash and `update_nodes` aborts the
-/// entire persist with `HashCollision`.
+/// do the same, or it hands both nodes one hash and the persist layer falls
+/// back to a body-blind re-salt that churns on every later compile (before
+/// #48 it aborted the entire persist with `HashCollision`).
 ///
 /// Regression: `keel compile` on this repo printed
 /// "failed to persist node updates: Hash collision detected for hash
@@ -330,7 +331,8 @@ fn same_named_defs_in_one_file_bind_to_distinct_nodes() {
 ///
 /// Disambiguating with the file path alone yields only a second identity, so
 /// defs 2 and 3 both landed on it and `update_nodes` aborted the entire
-/// persist with a `HashCollision` — leaving every node in the file stale.
+/// persist with a `HashCollision` (pre-#48; today it would re-salt blindly
+/// and churn) — either way, every def needs its own stable identity here.
 #[test]
 fn three_identical_defs_in_one_file_get_three_distinct_hashes() {
     let store = SqliteGraphStore::in_memory().unwrap();
@@ -378,7 +380,7 @@ fn three_identical_defs_in_one_file_get_three_distinct_hashes() {
     for (id, h) in hashes.iter().enumerate() {
         assert!(
             !h.starts_with("stale"),
-            "node {} kept its stale hash — the persist aborted: {:?}",
+            "node {} kept its stale hash — re-baseline failed to persist: {:?}",
             id + 1,
             hashes
         );
@@ -444,5 +446,73 @@ fn exact_line_matches_claim_their_node_before_name_only_fallback() {
     assert_ne!(
         node1.hash, node2.hash,
         "distinct bodies keep distinct hashes"
+    );
+}
+
+/// A collision absorbed by the persist layer's body-blind fallback
+/// (`persist_disambiguated_hash`) must converge to stable body-aware
+/// identities via the engine's re-baseline on the next compile of the file —
+/// the claim the fallback's doc comment makes (#48).
+#[test]
+fn persist_fallback_identity_converges_on_next_compile() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    // Force the persist-time fallback: two different-named nodes arrive with
+    // the same hash; update_nodes re-salts the second one body-blind.
+    store
+        .update_nodes(vec![keel_core::types::NodeChange::Add(make_node(
+            1,
+            "SHAREDhash1",
+            "alpha",
+            "fn alpha()",
+            "src/x.rs",
+        ))])
+        .unwrap();
+    store
+        .update_nodes(vec![keel_core::types::NodeChange::Add(make_node(
+            2,
+            "SHAREDhash1",
+            "beta",
+            "fn beta()",
+            "src/x.rs",
+        ))])
+        .unwrap();
+    let fallback = store.get_node_by_id(2).expect("collider persisted").hash;
+    assert_ne!(fallback, "SHAREDhash1", "collider was re-salted");
+
+    let mut engine = EnforcementEngine::new(Box::new(store));
+    let mut beta_def = make_definition("beta", "fn beta()", "{ 2 }", "src/x.rs");
+    beta_def.line_start = 30;
+    beta_def.line_end = 40;
+    let files = vec![FileIndex {
+        file_path: "src/x.rs".to_string(),
+        content_hash: 0,
+        definitions: vec![
+            make_definition("alpha", "fn alpha()", "{ 1 }", "src/x.rs"),
+            beta_def,
+        ],
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }];
+
+    engine.compile(&files);
+    let after_first: Vec<String> = (1u64..=2)
+        .map(|id| engine.store.get_node_by_id(id).expect("node survives").hash)
+        .collect();
+    assert_ne!(
+        after_first[1], fallback,
+        "body-blind fallback identity was replaced by a body-aware one"
+    );
+    assert_ne!(after_first[0], after_first[1], "identities stay distinct");
+
+    // Fixed point: a second identical compile must not churn the hashes.
+    engine.compile(&files);
+    let after_second: Vec<String> = (1u64..=2)
+        .map(|id| engine.store.get_node_by_id(id).expect("node survives").hash)
+        .collect();
+    assert_eq!(
+        after_first, after_second,
+        "identities are stable (converged)"
     );
 }

--- a/tests/contracts/test_graph_store_contract.rs
+++ b/tests/contracts/test_graph_store_contract.rs
@@ -6,7 +6,7 @@
 use keel_core::sqlite::SqliteGraphStore;
 use keel_core::store::GraphStore;
 use keel_core::types::{
-    EdgeChange, EdgeDirection, EdgeKind, GraphEdge, GraphError, GraphNode, NodeChange, NodeKind,
+    EdgeChange, EdgeDirection, EdgeKind, GraphEdge, GraphNode, NodeChange, NodeKind,
 };
 
 /// Helper to create a minimal test node.
@@ -333,25 +333,21 @@ fn contract_hash_collision_different_names() {
     let n1 = test_node(1, "collision_hash", "func_a", NodeKind::Function, 0);
     store.update_nodes(vec![NodeChange::Add(n1)]).unwrap();
 
+    // A different-named node claiming the same hash is re-salted, not
+    // rejected (#48) — the persist must never abort on a colliding pair.
     let n2 = test_node(2, "collision_hash", "func_b", NodeKind::Function, 0);
-    let result = store.update_nodes(vec![NodeChange::Add(n2)]);
-    assert!(
-        result.is_err(),
-        "Should detect hash collision for different function names"
-    );
+    store
+        .update_nodes(vec![NodeChange::Add(n2)])
+        .expect("collision must be auto-disambiguated, not fatal");
 
-    match result.unwrap_err() {
-        GraphError::HashCollision {
-            hash,
-            existing,
-            new_fn,
-        } => {
-            assert_eq!(hash, "collision_hash");
-            assert_eq!(existing, "func_a");
-            assert_eq!(new_fn, "func_b");
-        }
-        other => panic!("Expected HashCollision error, got: {:?}", other),
-    }
+    assert_eq!(
+        store.get_node("collision_hash").unwrap().name,
+        "func_a",
+        "existing node keeps its hash"
+    );
+    let salted = store.get_node_by_id(2).expect("collider persisted");
+    assert_eq!(salted.name, "func_b");
+    assert_ne!(salted.hash, "collision_hash");
 }
 
 #[test]

--- a/tests/graph/test_hash_collision.rs
+++ b/tests/graph/test_hash_collision.rs
@@ -3,7 +3,7 @@
 use keel_core::hash::{compute_hash, compute_hash_disambiguated};
 use keel_core::sqlite::SqliteGraphStore;
 use keel_core::store::GraphStore;
-use keel_core::types::{GraphError, GraphNode, NodeChange, NodeKind};
+use keel_core::types::{GraphNode, NodeChange, NodeKind};
 
 fn make_node(id: u64, hash: &str, name: &str, kind: NodeKind) -> GraphNode {
     GraphNode {
@@ -28,8 +28,10 @@ fn make_node(id: u64, hash: &str, name: &str, kind: NodeKind) -> GraphNode {
 }
 
 #[test]
-/// When two different functions produce the same hash, collision should be detected.
-fn test_collision_detected_on_duplicate_hash() {
+/// When two different functions produce the same hash, the collision is
+/// resolved by re-salting the second node — never by aborting the persist
+/// (#48: one colliding pair must not take down the gate for a whole repo).
+fn test_collision_auto_disambiguates_on_duplicate_hash() {
     // GIVEN two functions with different names that share the same hash
     let mut store = SqliteGraphStore::in_memory().expect("in-memory store");
     let colliding_hash = "abcDEF12345";
@@ -40,19 +42,20 @@ fn test_collision_detected_on_duplicate_hash() {
     let result_a = store.update_nodes(vec![NodeChange::Add(node_a)]);
     assert!(result_a.is_ok(), "First insert should succeed");
 
-    // THEN inserting the second node with the same hash but different name should error
-    let result_b = store.update_nodes(vec![NodeChange::Add(node_b)]);
-    assert!(
-        result_b.is_err(),
-        "Second insert with colliding hash should error"
-    );
+    // THEN inserting the second node with the same hash but different name
+    // succeeds under a file-path-salted hash
+    store
+        .update_nodes(vec![NodeChange::Add(node_b)])
+        .expect("collision must not abort the persist");
 
-    match result_b.unwrap_err() {
-        GraphError::HashCollision { hash, .. } => {
-            assert_eq!(hash, colliding_hash);
-        }
-        other => panic!("Expected HashCollision, got: {:?}", other),
-    }
+    assert_eq!(
+        store.get_node(colliding_hash).unwrap().name,
+        "func_alpha",
+        "original node keeps its hash"
+    );
+    let salted = store.get_node_by_id(2).expect("collider persisted");
+    assert_eq!(salted.name, "func_beta");
+    assert_ne!(salted.hash, colliding_hash, "collider got a distinct hash");
 }
 
 #[test]
@@ -94,66 +97,61 @@ fn test_disambiguated_hash_generation() {
 }
 
 #[test]
-/// Collision reporting should include both conflicting node names and the hash.
-fn test_collision_report_includes_both_nodes() {
-    // GIVEN a store with an existing node
+/// An Update that tries to claim a hash owned by a DIFFERENT node is re-salted
+/// instead of aborting (#48) — the owner keeps its hash.
+fn test_update_collision_auto_disambiguates() {
+    // GIVEN a store with two nodes under distinct hashes
     let mut store = SqliteGraphStore::in_memory().expect("in-memory store");
-    let hash = "XYZ98765432";
-    let node_existing = make_node(1, hash, "existing_func", NodeKind::Function);
+    let owned_hash = "XYZ98765432";
+    let node_owner = make_node(1, owned_hash, "existing_func", NodeKind::Function);
+    let node_other = make_node(2, "other4567890", "new_func", NodeKind::Function);
     store
-        .update_nodes(vec![NodeChange::Add(node_existing)])
-        .expect("first insert succeeds");
+        .update_nodes(vec![
+            NodeChange::Add(node_owner),
+            NodeChange::Add(node_other),
+        ])
+        .expect("seed inserts succeed");
 
-    // WHEN a second node with the same hash but different name is inserted
-    let node_new = make_node(2, hash, "new_func", NodeKind::Function);
-    let err = store
-        .update_nodes(vec![NodeChange::Add(node_new)])
-        .unwrap_err();
+    // WHEN node 2 is updated to claim node 1's hash
+    let mut claiming = make_node(2, owned_hash, "new_func", NodeKind::Function);
+    claiming.file_path = "other.rs".into();
+    store
+        .update_nodes(vec![NodeChange::Update(claiming)])
+        .expect("update collision must not abort the persist");
 
-    // THEN the error includes hash, existing function name, and new function name
-    match err {
-        GraphError::HashCollision {
-            hash: reported_hash,
-            existing,
-            new_fn,
-        } => {
-            assert_eq!(reported_hash, hash, "reported hash must match");
-            assert_eq!(existing, "existing_func", "existing name must match");
-            assert_eq!(new_fn, "new_func", "new function name must match");
-        }
-        other => panic!("Expected HashCollision, got: {:?}", other),
-    }
+    // THEN the owner keeps its hash and node 2 landed on a salted one
+    assert_eq!(store.get_node(owned_hash).unwrap().name, "existing_func");
+    let salted = store.get_node_by_id(2).expect("updated node persisted");
+    assert_ne!(salted.hash, owned_hash);
 }
 
 #[test]
-/// Insert first node OK, second with same hash but different name should error.
+/// Repeated collisions against the same hash each get their own salted
+/// identity — three same-hash inserts end as three distinct nodes.
 fn test_multiple_collisions_on_same_hash() {
     // GIVEN a store
     let mut store = SqliteGraphStore::in_memory().expect("in-memory store");
     let hash = "COLLIDEhash";
 
-    // WHEN the first node is inserted
-    let node1 = make_node(1, hash, "first_fn", NodeKind::Function);
-    let r1 = store.update_nodes(vec![NodeChange::Add(node1)]);
-    assert!(r1.is_ok(), "First insert should succeed");
-
-    // THEN the second node with same hash but different name triggers HashCollision
-    let node2 = make_node(2, hash, "second_fn", NodeKind::Function);
-    let r2 = store.update_nodes(vec![NodeChange::Add(node2)]);
-    assert!(r2.is_err(), "Second insert should fail with collision");
-
-    match r2.unwrap_err() {
-        GraphError::HashCollision {
-            hash: h,
-            existing,
-            new_fn,
-        } => {
-            assert_eq!(h, hash);
-            assert_eq!(existing, "first_fn");
-            assert_eq!(new_fn, "second_fn");
-        }
-        other => panic!("Expected HashCollision, got: {:?}", other),
+    // WHEN three different-named nodes are inserted under the same hash with
+    // identical signatures and file paths — the ordinal walk must separate
+    // them (a single file-path salt would give nodes 2 and 3 the same hash)
+    for (id, name) in [(1, "first_fn"), (2, "second_fn"), (3, "third_fn")] {
+        let mut node = make_node(id, hash, name, NodeKind::Function);
+        node.signature = "identical_sig()".into();
+        store
+            .update_nodes(vec![NodeChange::Add(node)])
+            .expect("collisions must not abort the persist");
     }
+
+    // THEN all three persisted with pairwise-distinct hashes
+    let hashes: Vec<String> = (1..=3)
+        .map(|id| store.get_node_by_id(id).expect("node persisted").hash)
+        .collect();
+    assert_eq!(hashes[0], hash, "first insert keeps the plain hash");
+    assert_ne!(hashes[0], hashes[1]);
+    assert_ne!(hashes[0], hashes[2]);
+    assert_ne!(hashes[1], hashes[2]);
 }
 
 #[test]

--- a/tests/graph/test_sqlite_advanced.rs
+++ b/tests/graph/test_sqlite_advanced.rs
@@ -1,7 +1,7 @@
 // Tests for SqliteGraphStore advanced features (Spec 000 - Graph Schema)
 //
-// Module profiles, resolution cache, circuit breaker, bulk atomicity,
-// concurrent reads, and auto-create schema.
+// Module profiles, resolution cache, circuit breaker, non-fatal bulk
+// collision handling, concurrent reads, and auto-create schema.
 
 use keel_core::sqlite::SqliteGraphStore;
 use keel_core::store::GraphStore;

--- a/tests/graph/test_sqlite_advanced.rs
+++ b/tests/graph/test_sqlite_advanced.rs
@@ -5,7 +5,7 @@
 
 use keel_core::sqlite::SqliteGraphStore;
 use keel_core::store::GraphStore;
-use keel_core::types::{GraphError, GraphNode, NodeChange, NodeKind};
+use keel_core::types::{GraphNode, NodeChange, NodeKind};
 
 fn make_node(id: u64, hash: &str, name: &str, kind: NodeKind) -> GraphNode {
     GraphNode {
@@ -216,8 +216,9 @@ fn test_sqlite_circuit_breaker_state() {
 }
 
 #[test]
-/// Bulk insertion with a duplicate hash (different name) should fail atomically.
-fn test_sqlite_bulk_insert_atomicity() {
+/// Bulk insertion with a duplicate hash (different name) must not abort the
+/// batch (#48) — the collider is re-salted and everything persists.
+fn test_sqlite_bulk_insert_collision_non_fatal() {
     let mut store = SqliteGraphStore::in_memory().unwrap();
 
     // Seed a node so the collision target exists
@@ -231,29 +232,18 @@ fn test_sqlite_bulk_insert_atomicity() {
         NodeChange::Add(make_node(4, "unique_b", "fn_b", NodeKind::Function)),
     ];
 
-    let result = store.update_nodes(batch);
-    assert!(
-        result.is_err(),
-        "batch with hash collision should fail: {:?}",
-        result
-    );
-    if let Err(GraphError::HashCollision { hash, .. }) = &result {
-        assert_eq!(hash, "dup_hash");
-    } else {
-        panic!("expected HashCollision error, got: {:?}", result);
-    }
+    store
+        .update_nodes(batch)
+        .expect("collision must not abort the batch (#48)");
 
-    // None of the batch nodes should have been persisted (transaction rolled back)
-    assert!(
-        store.get_node("unique_a").is_none(),
-        "transaction should have rolled back node unique_a"
-    );
-    assert!(
-        store.get_node("unique_b").is_none(),
-        "transaction should have rolled back node unique_b"
-    );
-    // Original node should still be intact
-    assert!(store.get_node("dup_hash").is_some());
+    // Every node persisted; the original keeps its hash, the collider got a
+    // salted one.
+    assert!(store.get_node("unique_a").is_some());
+    assert!(store.get_node("unique_b").is_some());
+    assert_eq!(store.get_node("dup_hash").unwrap().name, "original_fn");
+    let collider = store.get_node_by_id(3).expect("collider persisted");
+    assert_eq!(collider.name, "collider_fn");
+    assert_ne!(collider.hash, "dup_hash");
 }
 
 #[test]


### PR DESCRIPTION
Closes #48.

The released v0.4.2 binary was 75 commits behind main while both self-reported "keel 0.4.2" — CI consumers (zenzy-atlas among them) got a fatal `'stop'/'stop'` hash collision plus 159 phantom errors from missing svelte support and missing test-context exemptions. This PR delivers the two code asks and stages the release ask:

## Changes

**Persist-time hash collisions are now non-fatal** (`keel-core`). `update_nodes` no longer aborts the whole persist when a node claims a hash owned by a different node. Instead it re-salts the collider via `compute_hash_disambiguated` with a file-path ordinal walk (cap 64, mirroring the engine's salt loop) and warns on stderr. The original `HashCollision` error only surfaces if all 64 candidates are taken. One colliding pair can no longer take down the compile gate for an entire repo. Both the `Add` (different name, same hash) and `Update` (different id, same hash) arms are covered, and the existing-node hash is never touched.

**`--version` embeds the git short SHA** (`keel-cli`). A new `build.rs` emits `KEEL_VERSION_FULL` (`0.4.3 (abc123def)`), falling back to the plain version when there is no git context (crates.io builds). Two builds from different commits can never again masquerade as the same version — the masking that made #48 hard to see. `keel upgrade` version comparison is untouched (it uses `CARGO_PKG_VERSION` directly); install.sh and the homebrew formula do substring matches and are unaffected.

**Version bump 0.4.2 → 0.4.3** across the workspace, plus a CHANGELOG entry. After merge, tagging `v0.4.3` cuts the release; install.sh consumers (zenzy-atlas CI) heal automatically.

## Tests

Contract/unit tests that asserted the old fatal behavior now assert the non-fatal contract: collider persists under a salted hash, the original keeps its hash, batches complete, and a 3-way same-file collision exercises the ordinal walk. Full `cargo test --workspace` (27 suites), clippy `-D warnings`, `cargo fmt --check`, and `RUSTDOCFLAGS="-D warnings" cargo doc` all pass.
