### PR TITLE
Make E005 arity_mismatch reachable: resolve call targets before enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to keel will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **E005 arity_mismatch is reachable (#54).** No production site ever set
+  `Reference::resolved_to`, so the check compared nothing and E005 could not
+  fire outside unit tests. `keel compile` now resolves each compiled file's
+  call references against the pre-edit graph (the same ladder the edge sync
+  runs) before enforcement, at error-tier confidence only — a heuristic match
+  (unknown receiver, cross-package name, boundary surface) never escalates
+  into an arity ERROR. Call sites now carry a parser-counted argument count
+  (`Reference::call_arity`); splat/spread arguments, macro token trees, and
+  markup-derived "calls" record none and are skipped rather than guessed at.
+  Signatures are compared only when precisely countable (variadic, defaulted,
+  and optional parameter lists are skipped), a target compiled in the same
+  batch is judged against its freshly-parsed signature instead of the stored
+  one, and a type-qualified call (`Base.__init__(self, x)`, `Rc::clone(&x)`)
+  tolerates the explicitly-written receiver while a value-receiver call
+  (`registry.register(self)`) is compared exactly. Wired into `keel compile`,
+  `keel fix`, and `keel checkpoint`; the MCP server's `keel/compile` still
+  compiles without a resolution pass and keeps E005 silent for now (the
+  ladder lives in keel-cli, which the server cannot depend on).
+
 ## [0.5.0] - 2026-08-02
 
 ### Fixed

--- a/crates/keel-cli/src/commands/call_resolve.rs
+++ b/crates/keel-cli/src/commands/call_resolve.rs
@@ -301,6 +301,7 @@ mod tests {
             line: 7,
             kind: ReferenceKind::Literal,
             resolved_to: None,
+            call_arity: None,
         }
     }
 

--- a/crates/keel-cli/src/commands/checkpoint.rs
+++ b/crates/keel-cli/src/commands/checkpoint.rs
@@ -49,7 +49,7 @@ pub fn run(
     }
 
     let paths: Vec<PathBuf> = changed.iter().map(|f| cwd.join(f)).collect();
-    let file_indices = parse_files_to_indices(&paths, cwd);
+    let file_indices = parse_files_to_indices(&paths, cwd, store);
 
     // Diff against the PRE-edit graph before compiling: `engine.compile`
     // persists re-baselined hashes to the same database, which would erase the

--- a/crates/keel-cli/src/commands/compile.rs
+++ b/crates/keel-cli/src/commands/compile.rs
@@ -155,18 +155,6 @@ pub fn run(
     // literal edge it cannot reproduce would be deleted until the next map.
     let literal_keys = super::map_boundary::persisted_literal_keys(&cwd, &store);
 
-    let mut engine = keel_enforce::engine::EnforcementEngine::with_config(Box::new(store), &config);
-    engine.import_circuit_breaker(&cb_state);
-
-    // Apply suppressions
-    if let Some(code) = &suppress {
-        engine.suppress(code);
-    }
-
-    if batch_deferring {
-        engine.batch_start();
-    }
-
     // Whether the user explicitly named the target files (not --changed/--since,
     // not a bare full-repo compile). Only then is a missing file a hard error;
     // git-deleted paths under --changed/--since must still skip silently.
@@ -324,6 +312,34 @@ pub fn run(
         eprintln!("keel compile: checking {} file(s)", file_indices.len());
     }
 
+    // The same `ResolverSet` the map uses; `keel compile` only constructs
+    // resolvers for the languages it touched, so the untouched fields stay
+    // `None`. Shared by the pre-enforcement resolution pass here and the
+    // post-enforcement edge sync below.
+    let resolvers = super::map_lang_resolve::ResolverSet {
+        ts: ts.as_ref().map(|r| r as &dyn LanguageResolver),
+        py: py.as_ref().map(|r| r as &dyn LanguageResolver),
+        go: go_resolver.as_ref().map(|r| r as &dyn LanguageResolver),
+        rs: rs.as_ref().map(|r| r as &dyn LanguageResolver),
+    };
+
+    // Resolve call references against the pre-edit graph so E005 arity
+    // checking has real targets — before the engine takes ownership of the
+    // store, and before enforcement mutates anything.
+    super::compile_sync::resolve_call_targets(&store, &cwd, &mut file_indices, &resolvers);
+
+    let mut engine = keel_enforce::engine::EnforcementEngine::with_config(Box::new(store), &config);
+    engine.import_circuit_breaker(&cb_state);
+
+    // Apply suppressions
+    if let Some(code) = &suppress {
+        engine.suppress(code);
+    }
+
+    if batch_deferring {
+        engine.batch_start();
+    }
+
     let result = engine.compile(&file_indices);
 
     // Persist circuit-breaker state and run the incremental graph sync. Both
@@ -364,15 +380,6 @@ pub fn run(
             }
         }
         if need_sync {
-            // The same `ResolverSet` the map uses; `keel compile` only
-            // constructs resolvers for the languages it touched, so the
-            // untouched fields stay `None`.
-            let resolvers = super::map_lang_resolve::ResolverSet {
-                ts: ts.as_ref().map(|r| r as &dyn LanguageResolver),
-                py: py.as_ref().map(|r| r as &dyn LanguageResolver),
-                go: go_resolver.as_ref().map(|r| r as &dyn LanguageResolver),
-                rs: rs.as_ref().map(|r| r as &dyn LanguageResolver),
-            };
             super::compile_sync::sync_compiled_files(ps, &cwd, &file_indices, &resolvers, verbose);
         }
     }

--- a/crates/keel-cli/src/commands/compile_sync.rs
+++ b/crates/keel-cli/src/commands/compile_sync.rs
@@ -22,6 +22,12 @@
 //! diff against the pre-edit graph; the refreshed edges are then in place for
 //! the next compile. Only the compiled files' edges are re-resolved, keeping
 //! the single-file path well within its latency budget.
+//!
+//! The module's second job is the mirror image: [`resolve_call_targets`] runs
+//! the same ladder *before* enforcement, read-only, to populate
+//! [`Reference::resolved_to`] for E005 arity checking (issue #54). Both jobs
+//! share one per-reference entry point ([`resolve_reference`]) so they cannot
+//! drift.
 
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -33,11 +39,11 @@ use keel_core::sqlite::SqliteGraphStore;
 use keel_core::store::GraphStore;
 use keel_core::types::{EdgeChange, EdgeKind, GraphEdge, GraphNode, NodeChange, NodeKind};
 use keel_parsers::boundary::BoundaryProvider;
-use keel_parsers::resolver::{Definition, FileIndex};
+use keel_parsers::resolver::{Definition, FileIndex, Reference, ReferenceKind};
 use keel_parsers::treesitter::detect_language;
 
 use super::call_resolve::{
-    edge_for_reference, resolve_call_reference, tier_for_reference, CallSiteCtx,
+    edge_for_reference, resolve_call_reference, tier_for_reference, CallSiteCtx, ResolvedCall,
 };
 use super::map_lang_resolve::ResolverSet;
 use super::map_resolve::CallIndex;
@@ -176,6 +182,139 @@ impl CallIndex for GraphIndex<'_> {
     fn boundary_index(&self) -> &HashMap<String, (u64, f64)> {
         &self.base.boundary_index
     }
+}
+
+/// Resolve each compiled file's call references to their target node's hash
+/// *before* enforcement runs, populating [`Reference::resolved_to`] — the
+/// field E005 arity checking keys on (issue #54: nothing ever set it, so E005
+/// was unreachable).
+///
+/// Runs the same ladder as the post-enforcement edge sync below (via the
+/// shared [`resolve_reference`]), read-only against the pre-edit graph, plus
+/// two gates of its own that the edge sync does not apply. Only `Call`
+/// references that carry a syntactic argument count are resolved (they are
+/// the only ones E005 can judge), and only resolutions at error-tier
+/// confidence stick: a heuristic match (unknown receiver, cross-package name,
+/// boundary surface) must never escalate into an arity ERROR against what may
+/// be the wrong function.
+pub fn resolve_call_targets(
+    store: &SqliteGraphStore,
+    cwd: &Path,
+    files: &mut [FileIndex],
+    resolvers: &ResolverSet,
+) {
+    let countable_call = |r: &Reference| r.kind == ReferenceKind::Call && r.call_arity.is_some();
+    if !files.iter().flat_map(|f| &f.references).any(countable_call) {
+        return; // nothing E005 could judge — skip the index build entirely
+    }
+    let base = GraphIndexBase::build(store, cwd);
+    // id -> hash memo across the whole pass: repeated calls to one target must
+    // not re-run the store's full node load per call site.
+    let mut hash_memo: HashMap<u64, Option<String>> = HashMap::new();
+    for file in files.iter_mut() {
+        let FileIndex {
+            file_path,
+            references,
+            imports,
+            definitions,
+            ..
+        } = file;
+        if !references.iter().any(countable_call) {
+            continue;
+        }
+        let language = detect_language(Path::new(file_path.as_str())).unwrap_or("");
+        let abs_file = cwd.join(file_path.as_str());
+        // Bare-name -> node id for this file's stored defs, and the names that
+        // appear MORE THAN ONCE. A file legally holding two same-named defs (a
+        // free `search_graph` next to a `search_graph` method) collapses to
+        // one map entry, so a name-keyed binding is a coin flip — ambiguity
+        // must refuse to resolve rather than guess (same rule as the
+        // same-directory rung). Deliberately THIS pass only, not the shared
+        // `resolve_reference`: an ERROR-tier arity claim against the wrong
+        // sibling is worse than no claim, but the edge sync's best-effort
+        // binding still lands inside the right file/module, and pruning those
+        // edges would trade a rare mis-attributed edge for fresh W005 noise.
+        let mut local: HashMap<String, u64> = HashMap::new();
+        let mut ambiguous: HashSet<String> = HashSet::new();
+        for node in store.get_nodes_in_file(file_path) {
+            if node.kind == NodeKind::Module {
+                continue;
+            }
+            if local.insert(node.name.clone(), node.id).is_some() {
+                ambiguous.insert(node.name);
+            }
+        }
+        // The freshly-parsed definitions know duplicate names authoritatively
+        // — the stored side can lag (the edge sync inserts only one node per
+        // name), so a name the CURRENT file text defines twice is ambiguous
+        // even when the graph holds a single sibling.
+        let mut seen: HashSet<&str> = HashSet::new();
+        for def in definitions.iter() {
+            if !seen.insert(def.name.as_str()) {
+                ambiguous.insert(def.name.clone());
+            }
+        }
+        let idx = GraphIndex::new(&base, &local, file_path);
+        let ctx = CallSiteCtx {
+            resolvers,
+            language,
+            file_path,
+            abs_file: &abs_file,
+            imports,
+            definitions,
+        };
+        for reference in references.iter_mut() {
+            if !countable_call(reference) {
+                continue;
+            }
+            let Some(resolved) = resolve_reference(&local, &idx, &ctx, reference) else {
+                continue;
+            };
+            // Refuse only a SAME-FILE bind on an ambiguous name — that is the
+            // coin flip. The callee segment covers both `search_graph(..)`
+            // and `self.search_graph(..)`; a cross-file resolution of the
+            // same bare name (import, package) is unaffected by this file's
+            // local collision and stays eligible.
+            let callee = reference
+                .name
+                .rsplit(['.', ':'])
+                .next()
+                .unwrap_or(reference.name.as_str());
+            if ambiguous.contains(callee) && local.get(callee) == Some(&resolved.target_id) {
+                continue;
+            }
+            if resolved.confidence < keel_core::confidence::ERROR_TIER_THRESHOLD {
+                continue;
+            }
+            let hash = hash_memo
+                .entry(resolved.target_id)
+                .or_insert_with(|| store.get_node_by_id(resolved.target_id).map(|n| n.hash));
+            reference.resolved_to.clone_from(hash);
+        }
+    }
+}
+
+/// The ONE per-reference resolution entry both the pre-enforcement pass above
+/// and the edge sync's [`resolve_outgoing_edges`] use: a same-file direct name
+/// hit binds against the file's own definitions first (at the reference
+/// kind's same-file confidence, exactly as the map's first pass), everything
+/// else runs the shared ladder. Two mirrored copies of this sequence is the
+/// documented failure mode this module exists to prevent.
+fn resolve_reference(
+    local: &HashMap<String, u64>,
+    idx: &GraphIndex,
+    ctx: &CallSiteCtx,
+    reference: &Reference,
+) -> Option<ResolvedCall> {
+    if let Some(&target_id) = local.get(&reference.name) {
+        let (_, same_file_confidence) = edge_for_reference(&reference.kind)?;
+        return Some(ResolvedCall {
+            target_id,
+            confidence: same_file_confidence,
+            tier: tier_for_reference(&reference.kind).to_string(),
+        });
+    }
+    resolve_call_reference(idx, ctx, reference)
 }
 
 /// Refresh the graph for the compiled files. Best-effort: a failure is logged
@@ -393,29 +532,10 @@ fn resolve_outgoing_edges(
     };
 
     for reference in &file.references {
-        let Some((kind, same_file_confidence)) = edge_for_reference(&reference.kind) else {
+        let Some((kind, _)) = edge_for_reference(&reference.kind) else {
             continue;
         };
-        // Same-file direct reference: link against this file's own defs,
-        // exactly as the map's first pass does. The shared ladder only handles
-        // cross-file references (method calls still route through it via its
-        // same-file-method step).
-        if let Some(&tgt) = local.get(&reference.name) {
-            push_reference_edge(
-                file,
-                local,
-                reference.line,
-                tgt,
-                kind,
-                same_file_confidence,
-                tier_for_reference(&reference.kind),
-                next_id,
-                edge_changes,
-                node_tiers,
-            );
-            continue;
-        }
-        if let Some(resolved) = resolve_call_reference(&idx, &ctx, reference) {
+        if let Some(resolved) = resolve_reference(local, &idx, &ctx, reference) {
             push_reference_edge(
                 file,
                 local,
@@ -572,189 +692,5 @@ fn definition_node(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use keel_core::types::EdgeDirection;
-
-    fn def(name: &str, file: &str) -> Definition {
-        Definition {
-            name: name.to_string(),
-            kind: NodeKind::Function,
-            signature: format!("fn {}()", name),
-            file_path: file.to_string(),
-            line_start: 1,
-            line_end: 3,
-            docstring: None,
-            is_public: true,
-            type_hints_present: true,
-            body_text: "{ return 42; }".to_string(),
-            in_test_context: false,
-            in_trait_context: false,
-            is_associated: false,
-            is_auto_invoked: false,
-            is_decorated: false,
-            has_keep_marker: false,
-            is_macro: false,
-        }
-    }
-
-    fn index(file: &str, defs: Vec<Definition>) -> FileIndex {
-        FileIndex {
-            file_path: file.to_string(),
-            content_hash: 1,
-            definitions: defs,
-            references: vec![],
-            imports: vec![],
-            external_endpoints: vec![],
-            parse_duration_us: 0,
-        }
-    }
-
-    fn def_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Definition {
-        Definition {
-            line_start,
-            line_end,
-            ..def(name, file)
-        }
-    }
-
-    fn value_ref(name: &str, file: &str, line: u32) -> keel_parsers::resolver::Reference {
-        keel_parsers::resolver::Reference {
-            name: name.to_string(),
-            file_path: file.to_string(),
-            line,
-            kind: keel_parsers::resolver::ReferenceKind::Value,
-            resolved_to: None,
-        }
-    }
-
-    fn empty_resolvers() -> ResolverSet<'static> {
-        ResolverSet {
-            ts: None,
-            py: None,
-            go: None,
-            rs: None,
-        }
-    }
-
-    fn incoming_of(store: &SqliteGraphStore, file: &str, name: &str) -> Vec<GraphEdge> {
-        let node = store
-            .get_nodes_in_file(file)
-            .into_iter()
-            .find(|n| n.name == name)
-            .expect("node exists");
-        store.get_edges(node.id, EdgeDirection::Incoming)
-    }
-
-    /// A same-file callback reference (`spawn(handler)`) is a usage, not a
-    /// call: it must land as a `uses` edge so W005 stays quiet, and must never
-    /// become a `calls` edge that feeds arity/broken-caller checks.
-    #[test]
-    fn same_file_value_reference_becomes_a_uses_edge() {
-        let mut store = SqliteGraphStore::in_memory().unwrap();
-        let cwd = std::env::current_dir().unwrap();
-
-        let mut file = index(
-            "src/a.rs",
-            vec![
-                def_at("handler", "src/a.rs", 1, 3),
-                def_at("wire", "src/a.rs", 10, 12),
-            ],
-        );
-        file.references = vec![value_ref("handler", "src/a.rs", 11)];
-        sync_compiled_files(&mut store, &cwd, &[file], &empty_resolvers(), false);
-
-        let incoming = incoming_of(&store, "src/a.rs", "handler");
-        let uses: Vec<_> = incoming
-            .iter()
-            .filter(|e| e.kind == EdgeKind::Uses)
-            .collect();
-        assert_eq!(uses.len(), 1, "value ref must produce one uses edge");
-        assert!(
-            (uses[0].confidence - keel_core::confidence::SAME_FILE_VALUE_REF).abs() < f64::EPSILON
-        );
-        assert!(
-            !incoming.iter().any(|e| e.kind == EdgeKind::Calls),
-            "a value reference must never produce a calls edge"
-        );
-    }
-
-    /// The cross-file case W005 was false-positiving on: `child.rs` imports a
-    /// callback from `mod.rs` and passes it as a value. The import-based
-    /// resolution ladder must link it as a `uses` edge.
-    #[test]
-    fn cross_file_value_reference_resolves_to_a_uses_edge() {
-        let mut store = SqliteGraphStore::in_memory().unwrap();
-        let cwd = std::env::current_dir().unwrap();
-        let resolvers = empty_resolvers();
-
-        // The callback's defining file is already in the graph.
-        let owner = index(
-            "src/mod.rs",
-            vec![def_at("cross_file_cb", "src/mod.rs", 1, 3)],
-        );
-        sync_compiled_files(&mut store, &cwd, &[owner], &resolvers, false);
-
-        // The user's file references it as a value through an import.
-        let mut caller = index("src/child.rs", vec![def_at("wire", "src/child.rs", 5, 9)]);
-        caller.references = vec![value_ref("cross_file_cb", "src/child.rs", 7)];
-        caller.imports = vec![keel_parsers::resolver::Import {
-            source: "src/mod.rs".to_string(),
-            imported_names: vec!["cross_file_cb".to_string()],
-            file_path: "src/child.rs".to_string(),
-            line: 1,
-            is_relative: true,
-        }];
-        sync_compiled_files(&mut store, &cwd, &[caller], &resolvers, false);
-
-        let incoming = incoming_of(&store, "src/mod.rs", "cross_file_cb");
-        assert!(
-            incoming.iter().any(|e| e.kind == EdgeKind::Uses),
-            "cross-file value reference must resolve to a uses edge: {incoming:?}"
-        );
-        assert!(
-            !incoming.iter().any(|e| e.kind == EdgeKind::Calls),
-            "a value reference must never produce a calls edge"
-        );
-    }
-
-    /// Two files adding IDENTICAL new functions in one multi-file compile must
-    /// not share a hash: without the in-batch assigned-hash guard, the second
-    /// node silently overwrote the first's row and its edges dangled.
-    #[test]
-    fn same_batch_identical_defs_get_distinct_hashes() {
-        let mut store = SqliteGraphStore::in_memory().unwrap();
-        let cwd = std::env::current_dir().unwrap();
-        let resolvers = empty_resolvers();
-
-        let files = vec![
-            index("src/a.rs", vec![def("twin", "src/a.rs")]),
-            index("src/b.rs", vec![def("twin", "src/b.rs")]),
-        ];
-        sync_compiled_files(&mut store, &cwd, &files, &resolvers, false);
-
-        let a_nodes: Vec<_> = store
-            .get_nodes_in_file("src/a.rs")
-            .into_iter()
-            .filter(|n| n.kind == NodeKind::Function)
-            .collect();
-        let b_nodes: Vec<_> = store
-            .get_nodes_in_file("src/b.rs")
-            .into_iter()
-            .filter(|n| n.kind == NodeKind::Function)
-            .collect();
-        assert_eq!(a_nodes.len(), 1, "first file's node must survive");
-        assert_eq!(b_nodes.len(), 1, "second file's node must be inserted");
-        assert_ne!(
-            a_nodes[0].hash, b_nodes[0].hash,
-            "identical same-batch defs must get disambiguated hashes"
-        );
-        // Both files' Contains edges resolve to live nodes (nothing dangles).
-        for n in a_nodes.iter().chain(b_nodes.iter()) {
-            assert!(
-                !store.get_edges(n.id, EdgeDirection::Incoming).is_empty(),
-                "each node keeps its module Contains edge"
-            );
-        }
-    }
-}
+#[path = "compile_sync_tests.rs"]
+mod tests;

--- a/crates/keel-cli/src/commands/compile_sync_tests.rs
+++ b/crates/keel-cli/src/commands/compile_sync_tests.rs
@@ -1,0 +1,313 @@
+use super::*;
+use keel_core::types::EdgeDirection;
+
+fn def(name: &str, file: &str) -> Definition {
+    Definition {
+        name: name.to_string(),
+        kind: NodeKind::Function,
+        signature: format!("fn {}()", name),
+        file_path: file.to_string(),
+        line_start: 1,
+        line_end: 3,
+        docstring: None,
+        is_public: true,
+        type_hints_present: true,
+        body_text: "{ return 42; }".to_string(),
+        in_test_context: false,
+        in_trait_context: false,
+        is_associated: false,
+        is_auto_invoked: false,
+        is_decorated: false,
+        has_keep_marker: false,
+        is_macro: false,
+    }
+}
+
+fn index(file: &str, defs: Vec<Definition>) -> FileIndex {
+    FileIndex {
+        file_path: file.to_string(),
+        content_hash: 1,
+        definitions: defs,
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
+fn def_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Definition {
+    Definition {
+        line_start,
+        line_end,
+        ..def(name, file)
+    }
+}
+
+fn value_ref(name: &str, file: &str, line: u32) -> keel_parsers::resolver::Reference {
+    keel_parsers::resolver::Reference {
+        name: name.to_string(),
+        file_path: file.to_string(),
+        line,
+        kind: keel_parsers::resolver::ReferenceKind::Value,
+        resolved_to: None,
+        call_arity: None,
+    }
+}
+
+fn call_ref(name: &str, file: &str, line: u32, arity: u32) -> keel_parsers::resolver::Reference {
+    keel_parsers::resolver::Reference {
+        kind: ReferenceKind::Call,
+        call_arity: Some(arity),
+        ..value_ref(name, file, line)
+    }
+}
+
+/// Seed the graph with a two-def `src/a.rs` (callee at 1-3, caller at 10-12)
+/// and return its index — the shared fixture of the `resolve_call_targets`
+/// tests below.
+fn seeded_file(store: &mut SqliteGraphStore, cwd: &Path, resolvers: &ResolverSet) -> FileIndex {
+    let seed = index(
+        "src/a.rs",
+        vec![
+            def_at("callee", "src/a.rs", 1, 3),
+            def_at("caller", "src/a.rs", 10, 12),
+        ],
+    );
+    sync_compiled_files(store, cwd, std::slice::from_ref(&seed), resolvers, false);
+    seed
+}
+
+fn empty_resolvers() -> ResolverSet<'static> {
+    ResolverSet {
+        ts: None,
+        py: None,
+        go: None,
+        rs: None,
+    }
+}
+
+fn incoming_of(store: &SqliteGraphStore, file: &str, name: &str) -> Vec<GraphEdge> {
+    let node = store
+        .get_nodes_in_file(file)
+        .into_iter()
+        .find(|n| n.name == name)
+        .expect("node exists");
+    store.get_edges(node.id, EdgeDirection::Incoming)
+}
+
+/// A same-file callback reference (`spawn(handler)`) is a usage, not a
+/// call: it must land as a `uses` edge so W005 stays quiet, and must never
+/// become a `calls` edge that feeds arity/broken-caller checks.
+#[test]
+fn same_file_value_reference_becomes_a_uses_edge() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+
+    let mut file = index(
+        "src/a.rs",
+        vec![
+            def_at("handler", "src/a.rs", 1, 3),
+            def_at("wire", "src/a.rs", 10, 12),
+        ],
+    );
+    file.references = vec![value_ref("handler", "src/a.rs", 11)];
+    sync_compiled_files(&mut store, &cwd, &[file], &empty_resolvers(), false);
+
+    let incoming = incoming_of(&store, "src/a.rs", "handler");
+    let uses: Vec<_> = incoming
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Uses)
+        .collect();
+    assert_eq!(uses.len(), 1, "value ref must produce one uses edge");
+    assert!((uses[0].confidence - keel_core::confidence::SAME_FILE_VALUE_REF).abs() < f64::EPSILON);
+    assert!(
+        !incoming.iter().any(|e| e.kind == EdgeKind::Calls),
+        "a value reference must never produce a calls edge"
+    );
+}
+
+/// The cross-file case W005 was false-positiving on: `child.rs` imports a
+/// callback from `mod.rs` and passes it as a value. The import-based
+/// resolution ladder must link it as a `uses` edge.
+#[test]
+fn cross_file_value_reference_resolves_to_a_uses_edge() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+
+    // The callback's defining file is already in the graph.
+    let owner = index(
+        "src/mod.rs",
+        vec![def_at("cross_file_cb", "src/mod.rs", 1, 3)],
+    );
+    sync_compiled_files(&mut store, &cwd, &[owner], &resolvers, false);
+
+    // The user's file references it as a value through an import.
+    let mut caller = index("src/child.rs", vec![def_at("wire", "src/child.rs", 5, 9)]);
+    caller.references = vec![value_ref("cross_file_cb", "src/child.rs", 7)];
+    caller.imports = vec![keel_parsers::resolver::Import {
+        source: "src/mod.rs".to_string(),
+        imported_names: vec!["cross_file_cb".to_string()],
+        file_path: "src/child.rs".to_string(),
+        line: 1,
+        is_relative: true,
+    }];
+    sync_compiled_files(&mut store, &cwd, &[caller], &resolvers, false);
+
+    let incoming = incoming_of(&store, "src/mod.rs", "cross_file_cb");
+    assert!(
+        incoming.iter().any(|e| e.kind == EdgeKind::Uses),
+        "cross-file value reference must resolve to a uses edge: {incoming:?}"
+    );
+    assert!(
+        !incoming.iter().any(|e| e.kind == EdgeKind::Calls),
+        "a value reference must never produce a calls edge"
+    );
+}
+
+/// Two files adding IDENTICAL new functions in one multi-file compile must
+/// not share a hash: without the in-batch assigned-hash guard, the second
+/// node silently overwrote the first's row and its edges dangled.
+#[test]
+fn same_batch_identical_defs_get_distinct_hashes() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+
+    let files = vec![
+        index("src/a.rs", vec![def("twin", "src/a.rs")]),
+        index("src/b.rs", vec![def("twin", "src/b.rs")]),
+    ];
+    sync_compiled_files(&mut store, &cwd, &files, &resolvers, false);
+
+    let a_nodes: Vec<_> = store
+        .get_nodes_in_file("src/a.rs")
+        .into_iter()
+        .filter(|n| n.kind == NodeKind::Function)
+        .collect();
+    let b_nodes: Vec<_> = store
+        .get_nodes_in_file("src/b.rs")
+        .into_iter()
+        .filter(|n| n.kind == NodeKind::Function)
+        .collect();
+    assert_eq!(a_nodes.len(), 1, "first file's node must survive");
+    assert_eq!(b_nodes.len(), 1, "second file's node must be inserted");
+    assert_ne!(
+        a_nodes[0].hash, b_nodes[0].hash,
+        "identical same-batch defs must get disambiguated hashes"
+    );
+    // Both files' Contains edges resolve to live nodes (nothing dangles).
+    for n in a_nodes.iter().chain(b_nodes.iter()) {
+        assert!(
+            !store.get_edges(n.id, EdgeDirection::Incoming).is_empty(),
+            "each node keeps its module Contains edge"
+        );
+    }
+}
+
+/// The issue-#54 seam: `resolve_call_targets` populates `resolved_to` with
+/// the target node's hash for a same-file call, so E005 finally has a
+/// production site feeding it. A value reference must stay unresolved —
+/// it carries no argument list and must never reach arity checking.
+#[test]
+fn resolve_call_targets_sets_resolved_to_for_same_file_calls() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    let seed = seeded_file(&mut store, &cwd, &resolvers);
+    let callee_hash = store
+        .get_nodes_in_file("src/a.rs")
+        .into_iter()
+        .find(|n| n.name == "callee")
+        .expect("callee node")
+        .hash;
+
+    let mut file = seed;
+    file.references = vec![
+        call_ref("callee", "src/a.rs", 11, 2),
+        value_ref("callee", "src/a.rs", 11),
+    ];
+    let mut files = vec![file];
+    resolve_call_targets(&store, &cwd, &mut files, &resolvers);
+
+    assert_eq!(
+        files[0].references[0].resolved_to.as_deref(),
+        Some(callee_hash.as_str()),
+        "a same-file call resolves to the stored node's hash"
+    );
+    assert_eq!(
+        files[0].references[1].resolved_to, None,
+        "value references stay unresolved — no argument list, no E005"
+    );
+}
+
+/// A call without a syntactic argument count (attribute macros, markup
+/// hits) is skipped outright, and a warning-tier resolution must not
+/// stick: E005 is an ERROR and may only fire on error-tier targets.
+#[test]
+fn resolve_call_targets_skips_unknown_arity_and_warning_tier() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    let mut file = seeded_file(&mut store, &cwd, &resolvers);
+    let mut no_arity = call_ref("callee", "src/a.rs", 11, 0);
+    no_arity.call_arity = None;
+    // An unfamiliar-receiver method call resolves through the ladder at
+    // UNFAMILIAR_RECEIVER_METHOD (0.7) — below the error tier.
+    let unfamiliar = call_ref("obj.callee", "src/a.rs", 11, 1);
+    file.references = vec![no_arity, unfamiliar];
+    let mut files = vec![file];
+    resolve_call_targets(&store, &cwd, &mut files, &resolvers);
+    assert_eq!(
+        files[0].references[0].resolved_to, None,
+        "a call with no countable argument list must not resolve"
+    );
+    assert_eq!(
+        files[0].references[1].resolved_to, None,
+        "a warning-tier resolution must not feed E005"
+    );
+}
+
+/// A file that legally defines the same name twice (a free `search_graph`
+/// next to a `search_graph` method) collapses to one entry in the name-keyed
+/// local map — binding a same-file call against it is a coin flip, so the
+/// pre-enforcement pass must refuse to resolve it (dogfooding phantom from
+/// keel's own `queries.rs`).
+#[test]
+fn resolve_call_targets_refuses_same_file_ambiguous_names() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+
+    let seed = index(
+        "src/q.rs",
+        vec![
+            def_at("search_graph", "src/q.rs", 1, 3),
+            def_at("search_graph", "src/q.rs", 10, 12),
+            def_at("wire", "src/q.rs", 20, 24),
+        ],
+    );
+    sync_compiled_files(
+        &mut store,
+        &cwd,
+        std::slice::from_ref(&seed),
+        &resolvers,
+        false,
+    );
+
+    let mut file = seed;
+    file.references = vec![
+        call_ref("search_graph", "src/q.rs", 21, 4),
+        call_ref("self.search_graph", "src/q.rs", 22, 3),
+    ];
+    let mut files = vec![file];
+    resolve_call_targets(&store, &cwd, &mut files, &resolvers);
+
+    for r in &files[0].references {
+        assert_eq!(
+            r.resolved_to, None,
+            "`{}` must not resolve: the file defines the name twice",
+            r.name
+        );
+    }
+}

--- a/crates/keel-cli/src/commands/fix.rs
+++ b/crates/keel-cli/src/commands/fix.rs
@@ -39,10 +39,10 @@ pub fn run(
         vec![]
     };
 
+    // Parse files (resolving call targets against the pre-edit graph) before
+    // the engine takes ownership of the store, then compile to get violations.
+    let file_indices = super::parse_util::parse_files_to_indices(&file_paths, &cwd, &store);
     let mut engine = keel_enforce::engine::EnforcementEngine::new(Box::new(store));
-
-    // Parse files and compile to get violations
-    let file_indices = super::parse_util::parse_files_to_indices(&file_paths, &cwd);
     let compile_result = engine.compile(&file_indices);
 
     // Filter violations by hash if specified

--- a/crates/keel-cli/src/commands/map_resolve.rs
+++ b/crates/keel-cli/src/commands/map_resolve.rs
@@ -265,18 +265,28 @@ pub fn resolve_import_to_module(
 
 /// Resolve an unqualified cross-file call by looking in the same directory.
 /// In Go, all files in the same directory share a package namespace.
+///
+/// Requires a UNIQUE same-directory match. Two same-named definitions in the
+/// caller's directory (legal in every language but Go — e.g. this repo's
+/// `checkpoint::changed_files` next to `gitdiff::changed_files`) made this
+/// return whichever candidate the store listed first: a coin-flip edge that
+/// poisoned E001/E004/W005 quietly and, once E005 went live, flagged correct
+/// call sites against the wrong function's signature. Ambiguity now resolves
+/// to nothing — an unresolved reference, not a guessed one.
 pub fn resolve_same_directory_call(candidates: &[(String, u64)], caller_file: &str) -> Option<u64> {
     let caller_dir = Path::new(caller_file).parent()?.to_str()?;
+    let mut unique: Option<u64> = None;
     for (file, node_id) in candidates {
-        if file != caller_file {
-            if let Some(dir) = Path::new(file.as_str()).parent().and_then(|p| p.to_str()) {
-                if dir == caller_dir {
-                    return Some(*node_id);
-                }
+        if file != caller_file
+            && Path::new(file.as_str()).parent().and_then(|p| p.to_str()) == Some(caller_dir)
+        {
+            if unique.is_some() {
+                return None;
             }
+            unique = Some(*node_id);
         }
     }
-    None
+    unique
 }
 
 /// Resolve a cross-package import by matching a package name to nodes in that package.

--- a/crates/keel-cli/src/commands/map_resolve_tests.rs
+++ b/crates/keel-cli/src/commands/map_resolve_tests.rs
@@ -251,3 +251,38 @@ fn test_extract_package_name_variants() {
     assert_eq!(extract_package_name("crate::store"), None);
     assert_eq!(extract_package_name("super::sibling"), None);
 }
+
+/// The same-directory rung binds only on a UNIQUE match: two same-named
+/// definitions in the caller's directory (`checkpoint::changed_files` next to
+/// `gitdiff::changed_files`) used to resolve to whichever the store listed
+/// first — a coin-flip edge that fed E001/E004/W005 and, once E005 went live,
+/// compared correct call sites against the wrong function's signature.
+#[test]
+fn test_same_directory_call_requires_unique_match() {
+    let unique = vec![("src/gitdiff.rs".to_string(), 7u64)];
+    assert_eq!(
+        resolve_same_directory_call(&unique, "src/checkpoint_tests.rs"),
+        Some(7)
+    );
+
+    let ambiguous = vec![
+        ("src/checkpoint.rs".to_string(), 3u64),
+        ("src/gitdiff.rs".to_string(), 7u64),
+    ];
+    assert_eq!(
+        resolve_same_directory_call(&ambiguous, "src/checkpoint_tests.rs"),
+        None,
+        "two same-named defs in the directory is ambiguity, not a resolution"
+    );
+
+    // A candidate in a DIFFERENT directory does not make the same-dir match
+    // ambiguous.
+    let other_dir = vec![
+        ("src/gitdiff.rs".to_string(), 7u64),
+        ("other/place.rs".to_string(), 9u64),
+    ];
+    assert_eq!(
+        resolve_same_directory_call(&other_dir, "src/checkpoint_tests.rs"),
+        Some(7)
+    );
+}

--- a/crates/keel-cli/src/commands/parse_util.rs
+++ b/crates/keel-cli/src/commands/parse_util.rs
@@ -1,4 +1,5 @@
-//! Shared file-parsing logic used by both `compile` and `serve --watch`.
+//! Shared file-parsing logic for the commands that run `engine.compile()`
+//! outside `keel compile` itself (`keel fix`, `keel checkpoint`).
 
 use std::fs;
 use std::path::Path;
@@ -12,12 +13,16 @@ use keel_parsers::typescript::TsResolver;
 
 use keel_core::paths::make_relative;
 
-/// Parse a list of file paths into `FileIndex` entries suitable for `engine.compile()`.
+/// Parse a list of file paths into `FileIndex` entries suitable for
+/// `engine.compile()`, with call references resolved against the stored graph
+/// (`resolve_call_targets`) so E005 arity checking sees real targets on every
+/// compile path in this binary, not just `keel compile`.
 ///
 /// Skips files with unrecognized extensions or read errors.
 pub fn parse_files_to_indices(
     file_paths: &[std::path::PathBuf],
     root_dir: &Path,
+    store: &keel_core::sqlite::SqliteGraphStore,
 ) -> Vec<FileIndex> {
     let ts = TsResolver::with_project_root(root_dir);
     let py = PyResolver::detect();
@@ -50,6 +55,14 @@ pub fn parse_files_to_indices(
 
         indices.push(FileIndex::from_parse(&rel_path, &content, result));
     }
+
+    let resolvers = super::map_lang_resolve::ResolverSet {
+        ts: Some(&ts),
+        py: Some(&py),
+        go: Some(&go_resolver),
+        rs: Some(&rs),
+    };
+    super::compile_sync::resolve_call_targets(store, root_dir, &mut indices, &resolvers);
 
     indices
 }

--- a/crates/keel-enforce/src/circuit_breaker.rs
+++ b/crates/keel-enforce/src/circuit_breaker.rs
@@ -166,6 +166,36 @@ impl CircuitBreaker {
         }
     }
 
+    /// [`reset_resolved`](Self::reset_resolved) restricted to entries whose
+    /// recorded provenance is `file_path` (or that predate provenance
+    /// tracking). E005 needs this restriction: its entries are keyed by the
+    /// TARGET's hash, which every caller of that target shares — so without
+    /// it, any unrelated file that cleanly resolves the same target resets a
+    /// counter a *different* caller's failures accumulated, and lifts that
+    /// caller's downgrade behind its back.
+    fn reset_resolved_for_file(
+        &mut self,
+        codes: &[&str],
+        scope: &HashSet<String>,
+        active: &HashSet<(String, String)>,
+        file_path: &str,
+    ) {
+        let stale: Vec<(String, String)> = self
+            .state
+            .iter()
+            .filter(|(key, st)| {
+                codes.contains(&key.0.as_str())
+                    && scope.contains(&key.1)
+                    && (st.file == file_path || st.file.is_empty())
+                    && !active.contains(*key)
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in stale {
+            self.state.remove(&key);
+        }
+    }
+
     /// Clear tracked entries whose provenance is `file_path` but that did not
     /// fire this compile — regardless of whether their hash is still in scope.
     ///
@@ -196,7 +226,10 @@ impl CircuitBreaker {
     ///
     /// - E001/E002/E003/E004 are scoped to hashes of nodes already in the
     ///   file (plus the file path itself, for the empty-hash fallback).
-    /// - E005 is scoped to the hashes this file's call references resolve to.
+    /// - E005 is scoped to the hashes this file's call references resolve to,
+    ///   AND to entries this file's own compiles recorded — the target hash
+    ///   is shared by every caller, so hash scope alone would let one caller
+    ///   clear another's counter.
     ///
     /// Disabled checks (e.g. type_hints off) need no special-casing: their
     /// counters can never fire again, so clearing them is harmless.
@@ -224,7 +257,10 @@ impl CircuitBreaker {
             .collect();
 
         self.reset_resolved(&["E001", "E002", "E003", "E004"], &node_scope, &active);
-        self.reset_resolved(&["E005"], &ref_scope, &active);
+        // E005's key hash is the call TARGET's, shared by every caller — the
+        // reset must stay scoped to entries THIS file's compiles recorded, or
+        // one caller compiling clean would clear another caller's counter.
+        self.reset_resolved_for_file(&["E005"], &ref_scope, &active, file_path);
 
         // Provenance sweep: clear any entry that originated in this file but did
         // not re-fire — catches nodes/calls deleted from the file, whose hash is
@@ -426,6 +462,40 @@ mod tests {
             BreakerAction::WiderContext
         );
         assert_eq!(cb2.failure_count("E001", "abc", "file.rs"), 2);
+    }
+
+    #[test]
+    fn test_e005_reconcile_scoped_to_recording_file() {
+        // E005 entries are keyed by the call TARGET's hash, which every
+        // caller shares. A different caller compiling clean must not reset a
+        // counter (or lift a downgrade) another file's failures earned.
+        let mut cb = CircuitBreaker::new();
+        cb.record_failure("E005", "hashX", "fp1", "src/a.rs");
+        cb.record_failure("E005", "hashX", "fp2", "src/a.rs");
+        cb.record_failure("E005", "hashX", "fp3", "src/a.rs");
+        assert!(cb.is_downgraded("E005", "hashX", "src/a.rs"));
+
+        // src/c.rs also resolves target X — cleanly. A's state must survive.
+        cb.reconcile_file(
+            "src/c.rs",
+            std::iter::empty(),
+            ["hashX".to_string()].into_iter(),
+            &[],
+        );
+        assert!(
+            cb.is_downgraded("E005", "hashX", "src/a.rs"),
+            "another caller's clean compile must not lift this file's state"
+        );
+
+        // Compiling src/a.rs itself with the violation gone clears it.
+        cb.reconcile_file(
+            "src/a.rs",
+            std::iter::empty(),
+            ["hashX".to_string()].into_iter(),
+            &[],
+        );
+        assert!(!cb.is_downgraded("E005", "hashX", "src/a.rs"));
+        assert_eq!(cb.failure_count("E005", "hashX", "src/a.rs"), 0);
     }
 
     #[test]

--- a/crates/keel-enforce/src/engine.rs
+++ b/crates/keel-enforce/src/engine.rs
@@ -87,9 +87,13 @@ impl EnforcementEngine {
         // not visible to `get_node` until the transaction runs.
         let mut assigned_hashes: HashSet<String> = HashSet::new();
 
-        // Build batch file set: callers in the same compile batch are skipped
-        // by E001/E004 since the user likely updated them in the same commit.
-        let batch_file_set: HashSet<&str> = files.iter().map(|f| f.file_path.as_str()).collect();
+        // The compile batch as a lookup — E005 judges a call target compiled
+        // alongside against its freshly-parsed signature, not the stored one.
+        let batch_file_indices: std::collections::HashMap<&str, &FileIndex> =
+            files.iter().map(|f| (f.file_path.as_str(), f)).collect();
+        // Its key set: callers in the same compile batch are skipped by
+        // E001/E004 since the user likely updated them in the same commit.
+        let batch_file_set: HashSet<&str> = batch_file_indices.keys().copied().collect();
         // Economy-check state shared across the batch: names referenced
         // anywhere in it (W005) and body hashes seen so far (W006). Shared
         // with `keel review --base`, which must run W005/W006/W007 exactly as
@@ -123,8 +127,13 @@ impl EnforcementEngine {
                 &existing_nodes,
                 &batch_file_set,
             ));
-            // E005: arity mismatch
-            file_violations.extend(violations::check_arity_mismatch(file, &*self.store));
+            // E005: arity mismatch (batch-aware: same-batch targets are judged
+            // against their freshly-parsed signature)
+            file_violations.extend(violations::check_arity_mismatch(
+                file,
+                &*self.store,
+                &batch_file_indices,
+            ));
             // W001: placement (gated by config)
             if self.enforce_config.placement {
                 file_violations.extend(violations::check_placement(file, &*self.store));

--- a/crates/keel-enforce/src/engine_tests_economy.rs
+++ b/crates/keel-enforce/src/engine_tests_economy.rs
@@ -273,6 +273,7 @@ fn w005_counts_value_references_as_usage() {
             line: 21,
             kind: ReferenceKind::Value,
             resolved_to: None,
+            call_arity: None,
         }],
         imports: vec![],
         external_endpoints: vec![],

--- a/crates/keel-enforce/src/engine_tests_module_identity.rs
+++ b/crates/keel-enforce/src/engine_tests_module_identity.rs
@@ -108,6 +108,7 @@ fn w009_keeps_the_module_hash_when_a_definition_starts_on_its_line() {
         line: 12,
         kind: ReferenceKind::Call,
         resolved_to: None,
+        call_arity: None,
     }];
     file.imports = vec![Import {
         source: "core::ingest".into(),

--- a/crates/keel-enforce/src/test_fixtures.rs
+++ b/crates/keel-enforce/src/test_fixtures.rs
@@ -104,6 +104,7 @@ pub(crate) fn call_ref(name: &str, file: &str) -> Reference {
         line: 5,
         kind: ReferenceKind::Call,
         resolved_to: None,
+        call_arity: None,
     }
 }
 

--- a/crates/keel-enforce/src/violations_boundary_tests.rs
+++ b/crates/keel-enforce/src/violations_boundary_tests.rs
@@ -106,6 +106,7 @@ fn call(name: &str, line: u32, file: &str) -> Reference {
         line,
         kind: ReferenceKind::Call,
         resolved_to: None,
+        call_arity: None,
     }
 }
 

--- a/crates/keel-enforce/src/violations_extended.rs
+++ b/crates/keel-enforce/src/violations_extended.rs
@@ -6,7 +6,7 @@ use keel_parsers::resolver::FileIndex;
 
 use crate::types::{AffectedNode, Violation};
 use crate::violations_util::{
-    count_call_args, count_params, extract_prefix, is_test_file, normalize_signature,
+    extract_prefix, is_test_file, normalize_signature, parse_signature, receiver_is_type_like,
 };
 
 /// Check E004: function_removed — a function was removed but callers still exist.
@@ -91,19 +91,40 @@ pub fn check_removed_functions_with_cache(
 }
 
 /// Check E005: arity_mismatch — caller passes wrong number of arguments.
-/// Compares reference argument counts against definition parameter counts.
+/// Compares the parser-counted call-site arguments against the target
+/// definition's parameter count.
 ///
-/// **Open question — call-side receivers.** `count_params` strips a leading
-/// `self`/`cls`/`&self` from the definition; `count_call_args` strips nothing.
-/// The asymmetry is deliberate for now: a call site writing the receiver
-/// explicitly (`Base.__init__(self, x)`) is far rarer than one passing `self`
-/// as a real argument (`registry.register(self)`), so stripping both sides
-/// would swap a rare false positive for a common false negative. Nothing is
-/// currently affected — every reference reaching here needs `resolved_to`, and
-/// no production site sets it — so this is a decision to make when E005's
-/// resolution is wired up, with call-site context available to disambiguate.
-pub fn check_arity_mismatch(file: &FileIndex, store: &dyn GraphStore) -> Vec<Violation> {
+/// Honest by construction — the comparison only runs when every input is
+/// precisely known: the reference must be resolved (`resolved_to`, set by the
+/// compile pipeline's pre-enforcement resolution pass at error-tier confidence
+/// only), the call site must carry a syntactic argument count (`call_arity` is
+/// `None` for splats/spreads and call-shaped non-calls), and the signature
+/// must be exactly countable (`parse_signature` returns `None` for variadic,
+/// defaulted, or optional parameter lists).
+///
+/// **Call-side receivers.** `parse_signature` strips a definition-side
+/// `self`/`cls`/`this` (never written at an ordinary call site). The one call
+/// shape that *does* write the receiver as its first argument goes through
+/// the type — `Base.__init__(self, x)`, `Rc::clone(&x)` — so when the
+/// reference's receiver segment is type-like and the target can take an
+/// explicit receiver, one extra argument is tolerated. `registry.register
+/// (self)` (a value receiver passing `self` as a genuine argument) gets no
+/// tolerance and is compared exactly.
+///
+/// `batch_files` maps the file paths of this compile batch to their freshly
+/// parsed indices: when the target lives in the batch, its *current*
+/// signature wins over the stored (pre-edit) one, so changing a signature and
+/// its callers in the same compile is judged against the new contract.
+pub fn check_arity_mismatch(
+    file: &FileIndex,
+    store: &dyn GraphStore,
+    batch_files: &std::collections::HashMap<&str, &FileIndex>,
+) -> Vec<Violation> {
     let mut violations = Vec::new();
+    // hash -> stored node memo: a file typically calls the same target many
+    // times, and each store lookup is several SQLite statements.
+    let mut node_memo: std::collections::HashMap<&str, Option<keel_core::types::GraphNode>> =
+        std::collections::HashMap::new();
 
     for reference in &file.references {
         if reference.kind != keel_parsers::resolver::ReferenceKind::Call {
@@ -112,44 +133,92 @@ pub fn check_arity_mismatch(file: &FileIndex, store: &dyn GraphStore) -> Vec<Vio
         let Some(target_hash) = &reference.resolved_to else {
             continue;
         };
-
-        let Some(target_node) = store.get_node(target_hash) else {
+        let Some(call_arity) = reference.call_arity else {
+            continue;
+        };
+        if !node_memo.contains_key(target_hash.as_str()) {
+            node_memo.insert(target_hash.as_str(), store.get_node(target_hash));
+        }
+        let Some(target_node) = node_memo.get(target_hash.as_str()).and_then(|n| n.as_ref()) else {
             continue;
         };
 
-        // Count params from signature (rough heuristic: count commas + 1)
-        let expected_arity = count_params(&target_node.signature);
-        let call_arity = count_call_args(&reference.name);
+        // The freshest facts available: the batch's parsed definition if the
+        // target's file was compiled alongside, else the stored node. A batch
+        // file that no longer defines the target means the function was
+        // removed — that is E004's finding, not an arity comparison.
+        let (signature, is_associated) = match batch_files.get(target_node.file_path.as_str()) {
+            Some(target_file) => {
+                // Same-named defs can swap lines in one edit: prefer the
+                // exact (name, line) match, then fall back to name — but only
+                // when the name is UNIQUE in the file. Two same-named defs
+                // make the fallback a coin flip, and a wrong signature here
+                // becomes a wrong ERROR (same refusal rule as the resolution
+                // pass's ambiguity guards).
+                let defs = &target_file.definitions;
+                let def = defs
+                    .iter()
+                    .find(|d| d.name == target_node.name && d.line_start == target_node.line_start)
+                    .or_else(|| {
+                        let mut same_named = defs.iter().filter(|d| d.name == target_node.name);
+                        match (same_named.next(), same_named.next()) {
+                            (Some(only), None) => Some(only),
+                            _ => None,
+                        }
+                    });
+                match def {
+                    Some(def) => (def.signature.as_str(), def.is_associated),
+                    None => continue,
+                }
+            }
+            None => (target_node.signature.as_str(), target_node.is_associated),
+        };
+        let Some(sig) = parse_signature(signature) else {
+            continue;
+        };
 
-        // Only compare when both sides were parseable (count_params/count_call_args
-        // return 0 both for genuinely zero params AND for unparseable signatures).
-        // We flag mismatches when at least one side has params, which means the
-        // zero on the other side is a real zero (not a parse failure).
-        if (expected_arity > 0 || call_arity > 0) && expected_arity != call_arity {
-            violations.push(Violation {
-                code: "E005".to_string(),
-                severity: "ERROR".to_string(),
-                category: "arity_mismatch".to_string(),
-                message: format!(
-                    "Call to `{}` passes {} arg(s) but function expects {}",
-                    target_node.name, call_arity, expected_arity
-                ),
-                file: file.file_path.clone(),
-                line: reference.line,
-                hash: target_node.hash.clone(),
-                confidence: 0.85,
-                resolution_tier: "tree-sitter".to_string(),
-                fix_hint: Some(format!(
-                    "Update call to `{}` to pass {} argument(s)",
-                    target_node.name, expected_arity
-                )),
-                suppressed: false,
-                suppress_hint: None,
-                affected: vec![],
-                suggested_module: None,
-                existing: None,
-            });
+        // `is_associated` widens the receiver tolerance ONLY for Go: a Go
+        // method's stored signature carries no receiver token, so
+        // `has_receiver` cannot see it, yet a method expression `T.Scan(t, x)`
+        // legally writes the receiver first. For every other language an
+        // associated function without a receiver in its signature really
+        // takes none — `Foo::new(bogus, x)` is a genuine extra argument and
+        // must keep firing.
+        let go_method = is_associated
+            && keel_parsers::treesitter::detect_language(std::path::Path::new(
+                &target_node.file_path,
+            )) == Some("go");
+        let call_arity = call_arity as usize;
+        let explicit_receiver_ok = (sig.has_receiver || go_method)
+            && receiver_is_type_like(&reference.name)
+            && call_arity == sig.arity + 1;
+        if call_arity == sig.arity || explicit_receiver_ok {
+            continue;
         }
+
+        violations.push(Violation {
+            code: "E005".to_string(),
+            severity: "ERROR".to_string(),
+            category: "arity_mismatch".to_string(),
+            message: format!(
+                "Call to `{}` passes {} arg(s) but function expects {}",
+                target_node.name, call_arity, sig.arity
+            ),
+            file: file.file_path.clone(),
+            line: reference.line,
+            hash: target_node.hash.clone(),
+            confidence: 0.85,
+            resolution_tier: "tree-sitter".to_string(),
+            fix_hint: Some(format!(
+                "Update call to `{}` to pass {} argument(s)",
+                target_node.name, sig.arity
+            )),
+            suppressed: false,
+            suppress_hint: None,
+            affected: vec![],
+            suggested_module: None,
+            existing: None,
+        });
     }
 
     violations

--- a/crates/keel-enforce/src/violations_util.rs
+++ b/crates/keel-enforce/src/violations_util.rs
@@ -138,11 +138,26 @@ pub(crate) struct ParsedSig {
     pub(crate) arity: usize,
     /// Whether an explicit `-> T` follows the parameter list.
     pub(crate) has_return: bool,
+    /// Whether a leading `self`/`cls`/`this` receiver was removed from the
+    /// count — the signal that a call site *may* legally spell the receiver as
+    /// its first argument (`Base.__init__(self, x)`, `Rc::clone(&x)`).
+    pub(crate) has_receiver: bool,
 }
 
 /// True for characters that may appear inside an identifier.
 pub(crate) fn is_ident_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
+}
+
+/// True when the `'` at `chars[i]` opens a character literal (`'x'`, `'\n'`)
+/// rather than starting a Rust lifetime (`'a`, `'static`). A literal closes
+/// within two characters (one payload char, or a backslash escape); a lifetime
+/// is `'` + identifier with no closing quote at all. Treating a lifetime as a
+/// string opener swallowed everything up to the *next* tick — in
+/// `(node: Node<'a>, source: &'a [u8])` that includes the top-level comma, so
+/// the arity came out one short and E005 mis-fired on every caller.
+pub(crate) fn tick_opens_literal(chars: &[char], i: usize) -> bool {
+    matches!(chars.get(i + 1), Some('\\')) || matches!(chars.get(i + 2), Some('\''))
 }
 
 /// Index of the `)` closing the `(` at `open`, or `None` when the span is
@@ -164,7 +179,8 @@ pub(crate) fn match_paren(chars: &[char], open: usize) -> Option<usize> {
             continue;
         }
         match ch {
-            '"' | '\'' | '`' => in_str = Some(ch),
+            '"' | '`' => in_str = Some(ch),
+            '\'' if tick_opens_literal(chars, open + offset) => in_str = Some(ch),
             '\n' => {
                 newlines += 1;
                 if newlines > 6 {
@@ -187,14 +203,17 @@ pub(crate) fn match_paren(chars: &[char], open: usize) -> Option<usize> {
 
 /// Split an argument list on top-level commas, tracking `()`, `[]`, `{}`,
 /// generic `<>` (only when the `<` follows an identifier, so `a < b` is not a
-/// bracket) and string literals.
+/// bracket) and string literals. A `'` opens a literal only when it closes as
+/// one ([`tick_opens_literal`]) — a Rust lifetime tick must not swallow the
+/// rest of the list.
 pub(crate) fn split_top_level(args: &str) -> Vec<String> {
+    let chars: Vec<char> = args.chars().collect();
     let mut parts = Vec::new();
     let (mut round, mut square, mut curly, mut angle) = (0i32, 0i32, 0i32, 0i32);
     let mut in_str: Option<char> = None;
     let mut cur = String::new();
     let mut prev = '\0';
-    for ch in args.chars() {
+    for (i, &ch) in chars.iter().enumerate() {
         if let Some(q) = in_str {
             cur.push(ch);
             if ch == q && prev != '\\' {
@@ -204,7 +223,11 @@ pub(crate) fn split_top_level(args: &str) -> Vec<String> {
             continue;
         }
         match ch {
-            '"' | '\'' | '`' => {
+            '"' | '`' => {
+                in_str = Some(ch);
+                cur.push(ch);
+            }
+            '\'' if tick_opens_literal(&chars, i) => {
                 in_str = Some(ch);
                 cur.push(ch);
             }
@@ -253,8 +276,9 @@ pub(crate) fn split_top_level(args: &str) -> Vec<String> {
 
 /// Drop a leading receiver parameter (`self`, `&self`, `&mut self`, `cls`,
 /// `this`): it is never written at the call site, so counting it would make
-/// every method call look like it is one argument short.
-pub(crate) fn strip_receiver(parts: &mut Vec<String>) {
+/// every method call look like it is one argument short. Returns whether a
+/// receiver was actually removed.
+pub(crate) fn strip_receiver(parts: &mut Vec<String>) -> bool {
     let is_receiver = parts.first().is_some_and(|first| {
         let t = first
             .trim()
@@ -271,6 +295,7 @@ pub(crate) fn strip_receiver(parts: &mut Vec<String>) {
     if is_receiver {
         parts.remove(0);
     }
+    is_receiver
 }
 
 /// Countable argument count, or `None` when the list is variadic (`*args`,
@@ -303,59 +328,31 @@ pub(crate) fn parse_signature(sig: &str) -> Option<ParsedSig> {
     let close = match_paren(&chars, open)?;
     let args: String = chars[open + 1..close].iter().collect();
     let mut parts = split_top_level(&args);
-    strip_receiver(&mut parts);
+    let has_receiver = strip_receiver(&mut parts);
     let arity = countable_arity(&parts)?;
     let tail: String = chars[close + 1..].iter().collect();
     Some(ParsedSig {
         arity,
         has_return: tail.contains("->"),
+        has_receiver,
     })
 }
 
-/// Count parameters from a signature string. Returns 0 if unable to parse.
+/// True when a qualified call name's receiver segment names a *type* rather
+/// than a value — `Base.__init__`, `Rc::clone`, `Self::new` — the one call
+/// shape where the first written argument may legally be the receiver itself.
 ///
-/// Delegates to `parse_signature`, so a nested generic (`HashMap<K, V>` is one
-/// parameter, not two) and a receiver (`&self`/`cls`/`this`) are excluded from
-/// the count. Note this is deliberately NOT symmetric with `count_call_args`,
-/// which counts a textual `self`/`cls` argument — see the note there and on
-/// `check_arity_mismatch` for the open call-side question.
-/// A parameter list the precise parser declines to count at all — variadic,
-/// defaulted or optional — falls back to the naive comma split, keeping those
-/// signatures exactly as E005 compared them before.
-pub fn count_params(sig: &str) -> usize {
-    if let Some(parsed) = parse_signature(sig) {
-        return parsed.arity;
-    }
-    let Some(start) = sig.find('(') else { return 0 };
-    let Some(end) = sig.find(')') else { return 0 };
-    let params = sig[start + 1..end].trim();
-    if params.is_empty() {
-        return 0;
-    }
-    params.split(',').count()
-}
-
-/// Count args in a call expression. Rough heuristic — returns 0 if cannot parse.
-///
-/// Every comma-separated argument is counted, including a leading `self`/`cls`.
-/// That is *not* symmetric with `count_params`, which strips the receiver from
-/// the definition side — see the note on `check_arity_mismatch`. Stripping here
-/// too was tried and reverted: `registry.register(self)` passes `self` as a
-/// genuine argument far more often than a call site spells the receiver
-/// explicitly (`Base.__init__(self, x)`), so the strip trades a rare phantom
-/// `E005` for a common missed one. Settling it needs call-site context this
-/// function does not have.
-pub fn count_call_args(name: &str) -> usize {
-    // In practice, the parser provides arg count. This is a fallback.
-    let Some(start) = name.find('(') else {
-        return 0;
+/// The receiver is everything before the last `.`/`::`; only its final path
+/// segment is judged (so `mod::Type::method` looks at `Type`). Type-like means
+/// an uppercase initial (the universal type convention in all four languages)
+/// or the literal `Self`. A bare unqualified name has no receiver and is never
+/// type-like.
+pub(crate) fn receiver_is_type_like(call_name: &str) -> bool {
+    let Some(cut) = call_name.rfind("::").max(call_name.rfind('.')) else {
+        return false;
     };
-    let Some(end) = name.rfind(')') else { return 0 };
-    let args = &name[start + 1..end].trim();
-    if args.is_empty() {
-        return 0;
-    }
-    args.split(',').count()
+    let segment = call_name[..cut].rsplit(['.', ':']).next().unwrap_or("");
+    segment == "Self" || segment.starts_with(|c: char| c.is_uppercase())
 }
 
 /// Strip all whitespace so signatures can be compared ignoring pure
@@ -453,72 +450,84 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_count_params() {
-        assert_eq!(count_params("fn foo()"), 0);
-        assert_eq!(count_params("fn foo(a: i32)"), 1);
-        assert_eq!(count_params("fn foo(a: i32, b: str)"), 2);
-        assert_eq!(count_params("def bar(x, y, z)"), 3);
-    }
-
-    // E005 edge cases: zero params, many params, edge patterns
-    #[test]
-    fn test_count_params_zero() {
-        assert_eq!(count_params("fn foo()"), 0);
-        assert_eq!(count_params("def bar()"), 0);
-        assert_eq!(count_params("func Baz()"), 0);
-    }
-
-    #[test]
-    fn test_count_params_no_parens() {
-        assert_eq!(count_params("fn foo"), 0);
-        assert_eq!(count_params(""), 0);
-    }
-
-    #[test]
-    fn test_count_params_many() {
-        assert_eq!(count_params("fn f(a: i32, b: i32, c: i32, d: i32)"), 4);
-        assert_eq!(count_params("def g(a, b, c, d, e)"), 5);
+    fn test_parse_signature_counts_params() {
+        // Zero, one, many; nested generic/fn-pointer commas are one param.
+        assert_eq!(parse_signature("fn foo()").unwrap().arity, 0);
+        assert_eq!(parse_signature("fn foo(a: i32, b: str)").unwrap().arity, 2);
+        assert_eq!(parse_signature("def bar(x, y, z)").unwrap().arity, 3);
+        assert_eq!(
+            parse_signature("fn f(m: HashMap<String, i32>, n: u8)")
+                .unwrap()
+                .arity,
+            2
+        );
+        assert_eq!(
+            parse_signature("fn f(cb: fn(a: i32, b: i32) -> i32)")
+                .unwrap()
+                .arity,
+            1
+        );
+        assert!(parse_signature("fn foo").is_none());
     }
 
     #[test]
-    fn test_count_params_self_receiver() {
-        // The receiver is never written at the call site, so it is not counted:
-        // `obj.method(x)` passes one argument and the definition takes one.
-        assert_eq!(count_params("fn method(&self, x: i32)"), 1);
-        assert_eq!(count_params("def method(self, x)"), 1);
-        assert_eq!(count_params("fn method(&mut self)"), 0);
+    fn test_parse_signature_receiver_stripped_and_reported() {
+        // The receiver is never written at an ordinary call site, so it is not
+        // counted — but its presence is reported so E005 can tolerate the
+        // explicit-receiver call shape (`Base.__init__(self, x)`).
+        let sig = parse_signature("fn method(&self, x: i32)").unwrap();
+        assert_eq!(sig.arity, 1);
+        assert!(sig.has_receiver);
+        let sig = parse_signature("def method(self, x)").unwrap();
+        assert_eq!(sig.arity, 1);
+        assert!(sig.has_receiver);
+        let free = parse_signature("fn free(x: i32)").unwrap();
+        assert!(!free.has_receiver);
     }
 
     #[test]
-    fn test_count_params_nested_generics_are_one_param() {
-        // A comma inside `<>` / `()` / `[]` does not start a new parameter.
-        assert_eq!(count_params("fn f(m: HashMap<String, i32>)"), 1);
-        assert_eq!(count_params("fn f(m: HashMap<String, i32>, n: u8)"), 2);
-        assert_eq!(count_params("fn f(cb: fn(a: i32, b: i32) -> i32)"), 1);
+    fn test_parse_signature_rust_lifetimes_do_not_swallow_commas() {
+        // A lifetime tick used to open the "string literal" state, swallowing
+        // everything up to the next tick — including top-level commas. The
+        // repo's own `node_text(node: Node<'a>, source: &'a [u8])` counted as
+        // ONE parameter, so E005 flagged all 19 correct two-argument callers.
+        let sig =
+            parse_signature("node_text(node: tree_sitter::Node<'a>, source: &'a [u8]) -> &'a str")
+                .unwrap();
+        assert_eq!(sig.arity, 2);
+        assert!(sig.has_return);
+        // A lone lifetime (no second tick anywhere) must not unbalance the
+        // paren scan either.
+        let sig = parse_signature("first(x: &'a str)").unwrap();
+        assert_eq!(sig.arity, 1);
+        // Real character literals still open (and close) as literals.
+        let parts = split_top_level("'a', 'b'");
+        assert_eq!(parts.len(), 2);
+        // An escaped-quote char literal keeps its interior comma protected.
+        let parts = split_top_level("f(',', x), y");
+        assert_eq!(parts.len(), 2);
     }
 
     #[test]
-    fn test_count_params_uncountable_lists_keep_the_naive_count() {
-        // Variadic/defaulted/optional lists are not comparable to a call site;
-        // the fallback keeps E005's pre-existing behavior for them.
-        assert_eq!(count_params("def f(a, b=1)"), 2);
-        assert_eq!(count_params("def f(*args)"), 1);
-        assert_eq!(count_params("function f(a: number, b?: number)"), 2);
+    fn test_parse_signature_uncountable_lists_are_none() {
+        // Variadic/defaulted/optional lists are not comparable to a call
+        // site's argument count — E005 must skip them, not guess.
+        assert!(parse_signature("def f(a, b=1)").is_none());
+        assert!(parse_signature("def f(*args)").is_none());
+        assert!(parse_signature("function f(a: number, b?: number)").is_none());
     }
 
     #[test]
-    fn test_count_call_args_empty() {
-        assert_eq!(count_call_args("foo()"), 0);
-    }
-
-    #[test]
-    fn test_count_call_args_no_parens() {
-        assert_eq!(count_call_args("foo"), 0);
-    }
-
-    #[test]
-    fn test_count_call_args_multiple() {
-        assert_eq!(count_call_args("foo(a, b, c)"), 3);
+    fn test_receiver_is_type_like() {
+        assert!(receiver_is_type_like("Base.__init__"));
+        assert!(receiver_is_type_like("Rc::clone"));
+        assert!(receiver_is_type_like("Self::new"));
+        assert!(receiver_is_type_like("mod::Type::method"));
+        // Value receivers, packages, bare names: not type-like.
+        assert!(!receiver_is_type_like("registry.register"));
+        assert!(!receiver_is_type_like("self.render"));
+        assert!(!receiver_is_type_like("fmt.Println"));
+        assert!(!receiver_is_type_like("plain_call"));
     }
 
     #[test]

--- a/crates/keel-parsers/src/resolver.rs
+++ b/crates/keel-parsers/src/resolver.rs
@@ -249,6 +249,12 @@ pub struct Reference {
     pub kind: ReferenceKind,
     /// If already resolved, the hash/id of the target definition.
     pub resolved_to: Option<String>,
+    /// How many arguments the call site actually writes, when that is knowable
+    /// from syntax alone. `None` for non-call references, for call-shaped
+    /// references with no argument list (attribute macros, template markup
+    /// hits), and for argument lists containing a splat/spread — E005 arity
+    /// checking must skip all of those rather than compare against a guess.
+    pub call_arity: Option<u32>,
 }
 
 /// An import statement extracted from source.

--- a/crates/keel-parsers/src/rust_lang/mod.rs
+++ b/crates/keel-parsers/src/rust_lang/mod.rs
@@ -160,6 +160,7 @@ impl RustLangResolver {
                 line,
                 kind: ReferenceKind::TypeRef,
                 resolved_to: None,
+                call_arity: None,
             });
         }
         for (name, line) in helpers::extract_attribute_macros(content) {
@@ -169,6 +170,7 @@ impl RustLangResolver {
                 line,
                 kind: ReferenceKind::Call,
                 resolved_to: None,
+                call_arity: None,
             });
         }
 

--- a/crates/keel-parsers/src/treesitter/mod.rs
+++ b/crates/keel-parsers/src/treesitter/mod.rs
@@ -567,6 +567,10 @@ fn extract_references(
         let mut receiver = None;
         let mut line = 0u32;
         let mut is_call = false;
+        // The whole call-expression node, kept so the argument count can be
+        // read off its `arguments` field. Macro invocations never set it —
+        // their token tree is not an argument list.
+        let mut call_node: Option<tree_sitter::Node<'_>> = None;
         // Functions named as values rather than invoked. Collected separately
         // from calls so they never reach edge-building or E005 arity checks.
         let mut value_names: Vec<(String, u32)> = Vec::new();
@@ -629,6 +633,7 @@ fn extract_references(
                 }
                 "ref.call" => {
                     line = cap.node.start_position().row as u32 + 1;
+                    call_node = Some(cap.node);
                 }
                 "ref.macro_invocation.name" => {
                     // Capture macro invocations as calls with ! suffix
@@ -649,6 +654,7 @@ fn extract_references(
                 line: value_line,
                 kind: ReferenceKind::Value,
                 resolved_to: None,
+                call_arity: None,
             });
         }
 
@@ -659,6 +665,7 @@ fn extract_references(
                 line: literal_line,
                 kind: ReferenceKind::Literal,
                 resolved_to: None,
+                call_arity: None,
             });
         }
 
@@ -682,11 +689,44 @@ fn extract_references(
                     line,
                     kind: ReferenceKind::Call,
                     resolved_to: None,
+                    call_arity: call_node.and_then(call_argument_count),
                 });
             }
         }
     }
     refs
+}
+
+/// Count the arguments a call expression actually writes, reading the
+/// `arguments` field every grammar keel parses puts on its call node.
+///
+/// Returns `None` when the count is not knowable from syntax alone: no
+/// argument list at all (macro invocations), or a splat/spread argument
+/// (`f(*args)`, `f(...rest)`) that expands to an unknown number at runtime.
+/// Comments inside the argument list are named children in every grammar and
+/// must not count as arguments.
+fn call_argument_count(call_node: tree_sitter::Node<'_>) -> Option<u32> {
+    let args = call_node.child_by_field_name("arguments")?;
+    // The `arguments` field is not always an argument list: Python hangs a
+    // bare `generator_expression` there (`total(x for x in xs)`) and
+    // TypeScript a `template_string` for tagged templates (`` sql`...` ``).
+    // Their named children are comprehension/template internals, not
+    // arguments — counting them would hand E005 a wrong arity.
+    if !matches!(args.kind(), "arguments" | "argument_list") {
+        return None;
+    }
+    let mut count = 0u32;
+    let mut cursor = args.walk();
+    for child in args.named_children(&mut cursor) {
+        match child.kind() {
+            "comment" | "line_comment" | "block_comment" => {}
+            "list_splat" | "dictionary_splat" | "spread_element" | "variadic_argument" => {
+                return None
+            }
+            _ => count += 1,
+        }
+    }
+    Some(count)
 }
 
 /// Returns true when `lang` (a [`detect_language`] result) belongs to the
@@ -728,3 +768,6 @@ mod tests_literal_captures;
 
 #[cfg(test)]
 mod tests_import_names;
+
+#[cfg(test)]
+mod tests_call_arity;

--- a/crates/keel-parsers/src/treesitter/tests_call_arity.rs
+++ b/crates/keel-parsers/src/treesitter/tests_call_arity.rs
@@ -1,0 +1,90 @@
+//! Call-site argument-count extraction (issue #54): every language's call
+//! reference carries the syntactic arity E005 compares against signatures.
+
+use std::path::Path;
+
+use super::*;
+use crate::resolver::{ParseResult, ReferenceKind};
+
+/// The `call_arity` recorded for the call reference named `name`.
+fn arity_of(result: &ParseResult, name: &str) -> Option<u32> {
+    result
+        .references
+        .iter()
+        .find(|r| r.name == name && r.kind == ReferenceKind::Call)
+        .unwrap_or_else(|| panic!("call reference `{name}` extracted"))
+        .call_arity
+}
+
+/// Call references carry the syntactic argument count in every language —
+/// the input E005 arity checking compares against the target's signature
+/// (issue #54: references used to carry no count at all).
+#[test]
+fn call_references_carry_their_argument_count() {
+    let mut parser = TreeSitterParser::new();
+
+    let rust = "fn wire() {\n    plain(1, 2);\n    obj.method(1);\n    Vec::with_capacity(8);\n    none();\n}\n";
+    let result = parser.parse_file("rust", Path::new("a.rs"), rust).unwrap();
+    assert_eq!(arity_of(&result, "plain"), Some(2));
+    assert_eq!(arity_of(&result, "obj.method"), Some(1));
+    // A single-segment Rust path joins with `.` (existing extractor behavior).
+    assert_eq!(arity_of(&result, "Vec.with_capacity"), Some(1));
+    assert_eq!(arity_of(&result, "none"), Some(0));
+
+    let py = "def wire():\n    plain(1, 2)\n    obj.method(1)\n    kw(a, b=2)\n";
+    let result = parser.parse_file("python", Path::new("a.py"), py).unwrap();
+    assert_eq!(arity_of(&result, "plain"), Some(2));
+    assert_eq!(arity_of(&result, "obj.method"), Some(1));
+    assert_eq!(arity_of(&result, "kw"), Some(2));
+
+    let ts = "function wire() {\n    plain(1, 2);\n    obj.method(1);\n}\n";
+    let result = parser
+        .parse_file("typescript", Path::new("a.ts"), ts)
+        .unwrap();
+    assert_eq!(arity_of(&result, "plain"), Some(2));
+    assert_eq!(arity_of(&result, "obj.method"), Some(1));
+
+    let go = "package p\n\nfunc wire() {\n\tplain(1, 2)\n\tobj.Method(1)\n}\n";
+    let result = parser.parse_file("go", Path::new("a.go"), go).unwrap();
+    assert_eq!(arity_of(&result, "plain"), Some(2));
+    assert_eq!(arity_of(&result, "obj.Method"), Some(1));
+}
+
+/// A splat/spread/variadic argument expands to an unknown count at runtime,
+/// and a macro invocation has a token tree rather than an argument list — all
+/// must record `None`, never a guessed count, so E005 skips them. One case
+/// per grammar, so every language's uncountable shape stays pinned.
+#[test]
+fn uncountable_call_sites_record_no_arity() {
+    let mut parser = TreeSitterParser::new();
+
+    let py = "def wire():\n    splat(*args)\n    kwargs_splat(**kw)\n    gen(x for x in xs)\n";
+    let result = parser.parse_file("python", Path::new("a.py"), py).unwrap();
+    assert_eq!(arity_of(&result, "splat"), None, "`*args` splat");
+    assert_eq!(arity_of(&result, "kwargs_splat"), None, "`**kw` splat");
+    // A bare generator argument hangs a generator_expression on the
+    // `arguments` field — its named children are comprehension internals,
+    // not arguments, and must not be counted as two.
+    assert_eq!(arity_of(&result, "gen"), None, "generator argument");
+
+    let ts = "function wire() {\n    spread(...rest);\n    const q = sql`select ${x}`;\n}\n";
+    let result = parser
+        .parse_file("typescript", Path::new("a.ts"), ts)
+        .unwrap();
+    assert_eq!(arity_of(&result, "spread"), None, "`...rest` spread");
+    // A tagged template's `arguments` field is a template_string — its
+    // fragments are not an argument list.
+    assert_eq!(arity_of(&result, "sql"), None, "tagged template");
+
+    let go = "package p\n\nfunc wire() {\n\tspread(xs...)\n}\n";
+    let result = parser.parse_file("go", Path::new("a.go"), go).unwrap();
+    assert_eq!(arity_of(&result, "spread"), None, "Go `xs...` variadic");
+
+    let rust = "fn wire() {\n    println!(\"{}\", 1);\n}\n";
+    let result = parser.parse_file("rust", Path::new("a.rs"), rust).unwrap();
+    assert_eq!(
+        arity_of(&result, "println!"),
+        None,
+        "a macro token tree is not an argument list"
+    );
+}

--- a/crates/keel-parsers/src/typescript/svelte.rs
+++ b/crates/keel-parsers/src/typescript/svelte.rs
@@ -328,6 +328,7 @@ pub(crate) fn extract_template_references(
                             line,
                             kind,
                             resolved_to: None,
+                            call_arity: None,
                         });
                     }
                 }

--- a/tests/enforcement/test_arity_mismatch.rs
+++ b/tests/enforcement/test_arity_mismatch.rs
@@ -1,4 +1,10 @@
 // Tests for E005 arity mismatch detection (Spec 006 - Enforcement Engine)
+//
+// Since issue #54, E005 compares the parser-counted call-site arity
+// (`Reference::call_arity`) against a precisely-parsed signature, and only
+// for references the compile pipeline resolved (`resolved_to`).
+use std::collections::HashMap;
+
 use keel_core::hash::compute_hash;
 use keel_core::store::GraphStore;
 use keel_core::types::{GraphNode, NodeChange, NodeKind};
@@ -29,14 +35,31 @@ fn make_target(id: u64, name: &str, sig: &str) -> GraphNode {
     }
 }
 
-fn make_call_ref(name_with_args: &str, target_hash: &str, line: u32) -> Reference {
+fn make_call_ref(name: &str, target_hash: &str, arity: u32) -> Reference {
     Reference {
-        name: name_with_args.to_string(),
+        name: name.to_string(),
         file_path: "main.py".to_string(),
-        line,
+        line: 5,
         kind: ReferenceKind::Call,
         resolved_to: Some(target_hash.to_string()),
+        call_arity: Some(arity),
     }
+}
+
+fn file_with(references: Vec<Reference>) -> FileIndex {
+    FileIndex {
+        file_path: "main.py".to_string(),
+        content_hash: 0,
+        definitions: vec![],
+        references,
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    }
+}
+
+fn check(file: &FileIndex, store: &dyn GraphStore) -> Vec<keel_enforce::types::Violation> {
+    check_arity_mismatch(file, store, &HashMap::new())
 }
 
 #[test]
@@ -46,18 +69,8 @@ fn test_e005_added_required_parameter() {
     let target_hash = target.hash.clone();
     store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
 
-    let call_ref = make_call_ref("foo(1)", &target_hash, 5);
-    let file = FileIndex {
-        file_path: "main.py".to_string(),
-        content_hash: 0,
-        definitions: vec![],
-        references: vec![call_ref],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
-
-    let violations = check_arity_mismatch(&file, &store);
+    let file = file_with(vec![make_call_ref("foo", &target_hash, 1)]);
+    let violations = check(&file, &store);
     assert_eq!(violations.len(), 1);
     assert_eq!(violations[0].code, "E005");
     assert_eq!(violations[0].severity, "ERROR");
@@ -72,18 +85,8 @@ fn test_e005_removed_parameter() {
     let target_hash = target.hash.clone();
     store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
 
-    let call_ref = make_call_ref("bar(1, 2)", &target_hash, 10);
-    let file = FileIndex {
-        file_path: "main.py".to_string(),
-        content_hash: 0,
-        definitions: vec![],
-        references: vec![call_ref],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
-
-    let violations = check_arity_mismatch(&file, &store);
+    let file = file_with(vec![make_call_ref("bar", &target_hash, 2)]);
+    let violations = check(&file, &store);
     assert_eq!(violations.len(), 1);
     assert_eq!(violations[0].code, "E005");
 }
@@ -95,19 +98,8 @@ fn test_e005_matching_arity_no_violation() {
     let target_hash = target.hash.clone();
     store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
 
-    let call_ref = make_call_ref("ok(1, 2)", &target_hash, 5);
-    let file = FileIndex {
-        file_path: "main.py".to_string(),
-        content_hash: 0,
-        definitions: vec![],
-        references: vec![call_ref],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
-
-    let violations = check_arity_mismatch(&file, &store);
-    assert!(violations.is_empty());
+    let file = file_with(vec![make_call_ref("ok", &target_hash, 2)]);
+    assert!(check(&file, &store).is_empty());
 }
 
 #[test]
@@ -117,20 +109,10 @@ fn test_e005_includes_count_info() {
     let target_hash = target.hash.clone();
     store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
 
-    let call_ref = make_call_ref("xyz(1, 2)", &target_hash, 5);
-    let file = FileIndex {
-        file_path: "main.py".to_string(),
-        content_hash: 0,
-        definitions: vec![],
-        references: vec![call_ref],
-        imports: vec![],
-        external_endpoints: vec![],
-        parse_duration_us: 0,
-    };
-
-    let violations = check_arity_mismatch(&file, &store);
+    let file = file_with(vec![make_call_ref("xyz", &target_hash, 2)]);
+    let violations = check(&file, &store);
     assert_eq!(violations.len(), 1);
-    assert!(violations[0].message.contains("3") || violations[0].message.contains("2"));
+    assert!(violations[0].message.contains('3') && violations[0].message.contains('2'));
 }
 
 #[test]
@@ -140,19 +122,213 @@ fn test_e005_includes_fix_hint() {
     let target_hash = target.hash.clone();
     store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
 
-    let call_ref = make_call_ref("convert(1)", &target_hash, 5);
-    let file = FileIndex {
-        file_path: "main.py".to_string(),
+    let file = file_with(vec![make_call_ref("convert", &target_hash, 1)]);
+    let violations = check(&file, &store);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].fix_hint.is_some());
+    assert!(violations[0].fix_hint.as_ref().unwrap().contains("convert"));
+}
+
+#[test]
+fn test_e005_skips_unresolved_and_unknown_arity() {
+    let mut store = in_memory_store();
+    let target = make_target(1, "foo", "def foo(a: int, b: int)");
+    let target_hash = target.hash.clone();
+    store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
+
+    // Unresolved reference: no target to compare against.
+    let mut unresolved = make_call_ref("foo", &target_hash, 1);
+    unresolved.resolved_to = None;
+    // Unknown call arity (splat/spread, attribute macro): not comparable.
+    let mut no_arity = make_call_ref("foo", &target_hash, 0);
+    no_arity.call_arity = None;
+
+    let file = file_with(vec![unresolved, no_arity]);
+    assert!(check(&file, &store).is_empty());
+}
+
+#[test]
+fn test_e005_skips_uncountable_signatures() {
+    let mut store = in_memory_store();
+    // Variadic and defaulted parameter lists have no single "expected" count.
+    let variadic = make_target(1, "log", "def log(*args)");
+    let defaulted = make_target(2, "get", "def get(key, default=None)");
+    let variadic_hash = variadic.hash.clone();
+    let defaulted_hash = defaulted.hash.clone();
+    store
+        .update_nodes(vec![NodeChange::Add(variadic), NodeChange::Add(defaulted)])
+        .unwrap();
+
+    let file = file_with(vec![
+        make_call_ref("log", &variadic_hash, 5),
+        make_call_ref("get", &defaulted_hash, 1),
+    ]);
+    assert!(check(&file, &store).is_empty());
+}
+
+#[test]
+fn test_e005_tolerates_explicit_receiver_through_type() {
+    let mut store = in_memory_store();
+    let target = make_target(1, "__init__", "def __init__(self, x)");
+    let target_hash = target.hash.clone();
+    store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
+
+    // `Base.__init__(self, x)` writes the receiver explicitly: 2 written args
+    // against a stripped-receiver arity of 1 — legal through the type.
+    let file = file_with(vec![make_call_ref("Base.__init__", &target_hash, 2)]);
+    assert!(check(&file, &store).is_empty());
+
+    // Two EXTRA args through the type is still a real mismatch.
+    let file = file_with(vec![make_call_ref("Base.__init__", &target_hash, 3)]);
+    assert_eq!(check(&file, &store).len(), 1);
+}
+
+#[test]
+fn test_e005_value_receiver_gets_no_tolerance() {
+    let mut store = in_memory_store();
+    // `registry.register(self)` passes `self` as a genuine argument: the
+    // value receiver `registry` earns no off-by-one tolerance.
+    let target = make_target(1, "register", "def register(self, widget)");
+    let target_hash = target.hash.clone();
+    store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
+
+    let file = file_with(vec![make_call_ref("registry.register", &target_hash, 1)]);
+    assert!(check(&file, &store).is_empty());
+
+    let file = file_with(vec![make_call_ref("registry.register", &target_hash, 2)]);
+    assert_eq!(check(&file, &store).len(), 1);
+}
+
+#[test]
+fn test_e005_associated_target_tolerates_type_receiver_in_go_only() {
+    let mut store = in_memory_store();
+    // A Go method expression `T.Method(t, x)`: the stored signature carries no
+    // receiver token, but the node is marked associated, so the type-qualified
+    // call may still write the receiver as its first argument.
+    let mut target = make_target(1, "Scan", "Scan(x int)");
+    target.is_associated = true;
+    target.file_path = "lib.go".to_string();
+    let target_hash = target.hash.clone();
+    store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
+
+    let file = file_with(vec![make_call_ref("Table.Scan", &target_hash, 2)]);
+    assert!(check(&file, &store).is_empty());
+
+    // Outside Go the same shape is a REAL extra argument: a receiver-less
+    // associated function (`Foo::new`, a Python @staticmethod) takes exactly
+    // what its signature says, and `Foo.compute(bogus, x)` must fire.
+    let mut py_static = make_target(2, "compute", "def compute(x)");
+    py_static.is_associated = true;
+    let py_hash = py_static.hash.clone();
+    store
+        .update_nodes(vec![NodeChange::Add(py_static)])
+        .unwrap();
+
+    let file = file_with(vec![make_call_ref("Foo.compute", &py_hash, 2)]);
+    assert_eq!(
+        check(&file, &store).len(),
+        1,
+        "a receiver-less associated fn outside Go gets no tolerance"
+    );
+}
+
+#[test]
+fn test_e005_batch_signature_wins_over_stored() {
+    let mut store = in_memory_store();
+    // Stored contract: 2 params. The same compile batch re-parsed lib.py with
+    // a 3-param signature — the fresh contract is what callers are judged by.
+    let target = make_target(1, "foo", "def foo(a: int, b: int)");
+    let target_hash = target.hash.clone();
+    store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
+
+    let fresh_def = keel_parsers::resolver::Definition {
+        name: "foo".to_string(),
+        kind: NodeKind::Function,
+        signature: "def foo(a: int, b: int, c: int)".to_string(),
+        file_path: "lib.py".to_string(),
+        line_start: 1,
+        line_end: 5,
+        docstring: None,
+        is_public: true,
+        type_hints_present: true,
+        body_text: "pass".to_string(),
+        in_test_context: false,
+        in_trait_context: false,
+        is_associated: false,
+        is_auto_invoked: false,
+        is_decorated: false,
+        has_keep_marker: false,
+        is_macro: false,
+    };
+    let lib_file = FileIndex {
+        file_path: "lib.py".to_string(),
         content_hash: 0,
-        definitions: vec![],
-        references: vec![call_ref],
+        definitions: vec![fresh_def],
+        references: vec![],
         imports: vec![],
         external_endpoints: vec![],
         parse_duration_us: 0,
     };
+    let batch: HashMap<&str, &FileIndex> = [("lib.py", &lib_file)].into();
 
-    let violations = check_arity_mismatch(&file, &store);
-    assert_eq!(violations.len(), 1);
-    assert!(violations[0].fix_hint.is_some());
-    assert!(violations[0].fix_hint.as_ref().unwrap().contains("convert"));
+    // 3 args matches the fresh signature (would mismatch the stored one).
+    let file = file_with(vec![make_call_ref("foo", &target_hash, 3)]);
+    assert!(check_arity_mismatch(&file, &store, &batch).is_empty());
+
+    // 2 args matches the stale stored signature — now a real mismatch.
+    let file = file_with(vec![make_call_ref("foo", &target_hash, 2)]);
+    assert_eq!(check_arity_mismatch(&file, &store, &batch).len(), 1);
+}
+
+#[test]
+fn test_e005_ambiguous_batch_fallback_skips() {
+    let mut store = in_memory_store();
+    // Stored target at line 1; the batch file has moved things around AND
+    // legally holds TWO same-named defs. The exact (name, line) match fails
+    // and the name-only fallback is a coin flip — E005 must skip, not guess.
+    let target = make_target(1, "foo", "def foo(a: int, b: int)");
+    let target_hash = target.hash.clone();
+    store.update_nodes(vec![NodeChange::Add(target)]).unwrap();
+
+    let def_at = |line: u32, sig: &str| keel_parsers::resolver::Definition {
+        name: "foo".to_string(),
+        kind: NodeKind::Function,
+        signature: sig.to_string(),
+        file_path: "lib.py".to_string(),
+        line_start: line,
+        line_end: line + 3,
+        docstring: None,
+        is_public: true,
+        type_hints_present: true,
+        body_text: "pass".to_string(),
+        in_test_context: false,
+        in_trait_context: false,
+        is_associated: false,
+        is_auto_invoked: false,
+        is_decorated: false,
+        has_keep_marker: false,
+        is_macro: false,
+    };
+    let lib_file = FileIndex {
+        file_path: "lib.py".to_string(),
+        content_hash: 0,
+        definitions: vec![
+            def_at(10, "def foo(a: int)"),
+            def_at(30, "def foo(a: int, b: int, c: int)"),
+        ],
+        references: vec![],
+        imports: vec![],
+        external_endpoints: vec![],
+        parse_duration_us: 0,
+    };
+    let batch: HashMap<&str, &FileIndex> = [("lib.py", &lib_file)].into();
+
+    // Any arity: with two candidate contracts the comparison is unfoundable.
+    for arity in [1u32, 2, 3] {
+        let file = file_with(vec![make_call_ref("foo", &target_hash, arity)]);
+        assert!(
+            check_arity_mismatch(&file, &store, &batch).is_empty(),
+            "ambiguous batch fallback must skip (arity {arity})"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #54 — E005 arity_mismatch was unreachable: no production site ever set `Reference.resolved_to`, so the check compared nothing and never fired outside unit tests.

## What changed

**Resolution (the #54 core).** `keel compile` (and `keel fix`/`keel checkpoint` via `parse_util`) now runs a pre-enforcement pass — `resolve_call_targets` in `compile_sync.rs` — that resolves each compiled file's call references against the pre-edit graph using the same ladder the edge sync runs, and populates `resolved_to` with the target node's hash. Only resolutions at **error-tier confidence** (`>= ERROR_TIER_THRESHOLD`) stick: heuristic matches (unknown receivers, cross-package names, boundary surfaces) must never escalate into an arity ERROR against what may be the wrong function. The per-reference "same-file first, then ladder" sequence is now one shared helper (`resolve_reference`) used by both the pre-pass and `resolve_outgoing_edges`, so the two cannot drift.

**Call-side arity (new parser fact).** `reference.name` never carried an argument list, so the old `count_call_args` always returned 0 — naively wiring `resolved_to` would have made E005 fire on every resolved call. References now carry `call_arity: Option<u32>`, counted from the call node's `arguments` field. `None` — and therefore an E005 skip — for: splat/spread/variadic arguments (`f(*args)`, `f(...rest)`, `f(xs...)`), macro token trees, attribute-macro pseudo-calls, and markup-derived references.

**Signature side.** E005 compares only precisely countable signatures (`parse_signature`; variadic/defaulted/optional lists are skipped, never guessed). A target compiled in the same batch is judged against its freshly-parsed signature, not the stored one.

**Receiver counting (the #54 open question).** Implemented the issue's type-like-receiver heuristic: a type-qualified call (`Base.__init__(self, x)`, `Rc::clone(&x)`, uppercase-initial or `Self` receiver segment) tolerates exactly one extra argument when the target can take an explicit receiver (`sig.has_receiver`, or `is_associated` for Go's receiver-less stored signatures). A value-receiver call (`registry.register(self)`) is compared exactly — no strip, so the previously-reverted receiver-strip false negatives do not return.

## Phantoms found by dogfooding (fixed here)

Running the wired E005 over keel's own codebase surfaced 12 phantom errors, all pre-existing latent bugs that only became consequential once E005 went live:

- **Rust lifetimes poisoned arity parsing.** A `'` opened the "string literal" state in `split_top_level`/`match_paren`, so `'a` in `node_text(node: Node<'a>, source: &'a [u8])` swallowed the top-level comma — arity 1 instead of 2, flagging all 19 correct callers. `tick_opens_literal` now distinguishes a char literal (closes within two chars) from a lifetime (never closes).
- **Same-directory resolution was a coin flip.** `resolve_same_directory_call` returned the *first* same-dir candidate; with two same-named functions in one directory (`checkpoint::changed_files` vs `gitdiff::changed_files`) the edge — and now the arity comparison — could bind to the wrong one. The rung now requires a unique match. This also deletes ~560 garbage edges in this repo's own graph that previously fed E001/E004/W005.
- **Same-file name collisions were a coin flip too.** A file defining both a free `search_graph` and a `search_graph` method collapsed to one entry in the name-keyed local map. The pre-pass now refuses a *same-file bind* on a name its file defines more than once (ambiguity judged from both the stored nodes and the fresh parse); cross-file resolutions of the same bare name stay eligible.

## Hardening from the quality loop

- **Circuit-breaker scoping.** E005 breaker entries are keyed by the call *target's* hash, which every caller shares — the reconcile reset is now restricted to entries the compiled file's own compiles recorded, so one caller compiling clean can no longer reset a counter (or lift a downgrade) a different caller's failures earned. Regression test included.
- **Arity is refused where syntax can't count it:** Python generator-expression arguments (`total(x for x in xs)`) and TS tagged templates (`` sql`...` ``) hang non-argument-list nodes on the call's `arguments` field and now record `None` instead of a wrong count.
- **The receiver tolerance's `is_associated` widening is Go-only** (Go stored signatures carry no receiver token). Elsewhere a receiver-less associated function (`Foo::new`, a `@staticmethod`) gets no tolerance — `Foo.compute(bogus, x)` keeps firing.
- **The batch fresh-signature fallback requires a unique name match** — two same-named defs in a batch file make the comparison unfoundable, so E005 skips rather than guesses.

## Known limits / follow-ups

- `keel-server`'s `keel/compile` (MCP/HTTP/watch) still compiles without a resolution pass — the ladder lives in `keel-cli`, a binary crate the server cannot depend on (same pre-existing asymmetry as the edge sync). E005 stays silent there for now.
- Full-repo compiles can surface W009 `new_cross_boundary_dep` warnings after the edge sync erodes cross-package baselines — **pre-existing** (reproducible on v0.5.0: second full compile fires 6 of them) and tracked as the "W009 replay" open item from the v0.5 plan; the honest-edges change here makes a previously-lucky baseline smaller, so the count can rise.
- W002 flags the cargo-mandated `fn main` pair in `build.rs`/`src/main.rs` on full-repo compiles — pre-existing false positive, candidate for an entrypoint exemption.

## Tests

- Parser: per-language call-arity extraction + uncountable shapes (splat/spread/Go variadic/macro) pinned per grammar.
- `violations_util`: lifetime regression (`node_text`'s exact signature), receiver reporting, uncountable signatures, type-like receiver.
- `check_arity_mismatch`: added/removed params, skip rules (unresolved, unknown arity, uncountable sigs), explicit-receiver tolerance both ways, batch-fresh signature override.
- `resolve_call_targets`: same-file hash resolution, value-ref exclusion, unknown-arity skip, warning-tier gate.
- `resolve_same_directory_call`: uniqueness contract.
- End-to-end verified: same-file and cross-file arity mismatches produce `E005 ... exit 1` from a real `keel map` + `keel compile`; correct-arity and explicit-receiver files stay silent with empty stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iDgAfwqPdun8WX3FnrPPk
