### PR TITLE
Stop keel compile eroding cross-file call edges: per-reference keep/replace

### DIFF
--- a/crates/keel-cli/src/commands/call_resolve.rs
+++ b/crates/keel-cli/src/commands/call_resolve.rs
@@ -11,10 +11,14 @@
 //! compile`, leaving them gone until the next full map.
 //!
 //! This module hosts ONE ladder, run by both pipelines through the
-//! [`CallIndex`] seam, so a compile's
-//! re-resolution reproduces exactly the edges the map would — the prune is
-//! lossless. The two pipelines differ only in how they back `CallIndex`: the
-//! map with its in-memory indices, the compile sync with graph-backed lookups.
+//! [`CallIndex`] seam, so every edge a compile *can* re-resolve is
+//! reproduced at map quality. The two pipelines differ only in how they back
+//! `CallIndex`: the map with its in-memory indices, the compile sync with
+//! graph-backed lookups. Sharing the rungs does not share the *inputs*,
+//! though — compile-time tier-2 resolvers have parsed only the compiled
+//! files — so references can still fail to re-resolve at compile time;
+//! `compile_sync` keeps their stored edges instead of pruning them (see its
+//! module docs for the keep/replace policy).
 
 use std::path::Path;
 

--- a/crates/keel-cli/src/commands/compile_sync.rs
+++ b/crates/keel-cli/src/commands/compile_sync.rs
@@ -7,16 +7,36 @@
 //! - insert nodes for definitions new since the last map,
 //! - remove nodes for definitions that vanished from a file,
 //! - re-resolve each compiled file's outgoing reference edges — `calls` plus
-//!   the `uses` edges of functions named as values (prune + re-add).
+//!   the `uses` edges of functions named as values (replace, never wholesale
+//!   prune).
 //!
 //! Re-resolution runs the SAME ladder as the map's second pass
 //! ([`super::call_resolve::resolve_call_reference`]), backed here by
 //! graph-backed lookups ([`GraphIndex`]) instead of the map's in-memory
-//! indices. That is the whole point: an earlier version re-implemented a weaker
-//! ladder and, because it prunes a file's call edges before re-resolving, every
-//! `keel compile` deleted the method-call, same-directory, package, and
-//! boundary edges the map had built. Running the map's own ladder makes the
-//! prune lossless.
+//! indices. The ladder's *rungs* match the map's, but its *inputs* do not:
+//! the map's tier-2 resolvers have parsed the whole repo, while compile-time
+//! resolvers have parsed only the compiled files, so cross-file references
+//! the map resolved through tier 2 routinely fail to re-resolve here. A
+//! reference that fails to re-resolve therefore proves NOTHING about whether
+//! its call site still exists. The sync deletes a stored edge only on
+//! positive evidence: it re-resolved the same (source, target, kind) this
+//! pass, or the target lives inside the compiled file itself — where the
+//! ladder has complete information and replacement is at map parity. Every
+//! other stored edge is kept; a genuinely deleted cross-file call site keeps
+//! its edge until the next `keel map` rebuilds the graph (bounded staleness,
+//! the accepted trade — an earlier version pruned a file's edges wholesale
+//! and re-added what re-resolved, so ONE compile permanently erased a file's
+//! tier-2/cross-crate edges, eroding E001/E004/W005/`keel discover` and
+//! W009's stored-boundary baseline until the next full map).
+//!
+//! The keep rule deliberately covers `uses` edges too, superseding the old
+//! prune's rationale for including them ("leaving `uses` behind would keep a
+//! deleted value reference alive forever"): a deleted cross-file value
+//! reference now keeps its edge until the next map, so W005 can under-report
+//! a dead callback between maps — the mirror image of the false POSITIVES
+//! that wholesale-pruning live `uses` edges produced, and the cheaper error:
+//! it is bounded, and same-file `uses` edges (the common W005 case) are
+//! still replaced wholesale by the intra-file rule.
 //!
 //! It runs *after* enforcement (on a separate store handle) so E001/E004 still
 //! diff against the pre-edit graph; the refreshed edges are then in place for
@@ -335,10 +355,11 @@ pub fn sync_compiled_files(
     // compile must not share a hash, or the second silently overwrites the
     // first's row and its edges dangle.
     let mut assigned_hashes: HashSet<String> = HashSet::new();
-    // Edge prunes are deferred to the write phase: pruning during the read
-    // phase is a committed DELETE, so a later node-write failure would leave
-    // the file's outgoing edges destroyed with nothing re-added.
-    let mut files_to_prune: Vec<String> = Vec::new();
+    // Stored edge ids each file's keep/replace decision marked for deletion.
+    // Deferred to the write phase: deleting during the read phase would be a
+    // committed DELETE, so a later node-write failure would leave the file's
+    // outgoing edges destroyed with nothing re-added.
+    let mut edge_removals: Vec<u64> = Vec::new();
 
     // Files in this compile batch: a vanished definition with callers only in
     // these files was fixed in the same pass, so its node may be pruned. One
@@ -363,7 +384,7 @@ pub fn sync_compiled_files(
                 &mut edge_changes,
                 &mut node_tiers,
                 &mut assigned_hashes,
-                &mut files_to_prune,
+                &mut edge_removals,
             );
         }
     }
@@ -379,13 +400,17 @@ pub fn sync_compiled_files(
             return;
         }
     }
-    for rel_path in &files_to_prune {
-        if let Err(e) = store.prune_call_edges_from_file(rel_path) {
-            let _ = e; // best-effort; fresh edges for this file are added next
-        }
-    }
-    if !edge_changes.is_empty() {
-        if let Err(e) = store.update_edges(edge_changes) {
+    if !edge_removals.is_empty() || !edge_changes.is_empty() {
+        // Removals FIRST: `update_edges` applies changes in order and adds
+        // are INSERT OR IGNORE, so an add for an unchanged call site (same
+        // line) would be ignored against the still-present old row and a
+        // later removal would then delete the only copy.
+        let changes: Vec<EdgeChange> = edge_removals
+            .into_iter()
+            .map(EdgeChange::Remove)
+            .chain(edge_changes)
+            .collect();
+        if let Err(e) = store.update_edges(changes) {
             if verbose {
                 eprintln!("keel compile: graph sync (edges) failed: {}", e);
             }
@@ -410,8 +435,20 @@ fn sync_one_file(
     edge_changes: &mut Vec<EdgeChange>,
     node_tiers: &mut HashMap<u64, String>,
     assigned_hashes: &mut HashSet<String>,
-    files_to_prune: &mut Vec<String>,
+    edge_removals: &mut Vec<u64>,
 ) {
+    // A parse that produced zero definitions is far more likely a transient
+    // parse failure (an on-edit hook compiling mid-edit syntax) than a file
+    // genuinely emptied out. Treat it as no-evidence and leave the graph
+    // exactly as it was — no node removals, no edge replacement; the next
+    // successful compile or `keel map` supplies the real state. E004/E001
+    // already ran against the pre-sync graph, so detection loses nothing.
+    // (With no definitions there is also no containing def to attribute any
+    // reference edge to, so nothing below could produce output anyway.)
+    if file.definitions.is_empty() {
+        return;
+    }
+
     let store = base.store;
     let rel_path = &file.file_path;
     let existing = store.get_nodes_in_file(rel_path);
@@ -488,10 +525,15 @@ fn sync_one_file(
         local.remove(&node.name);
     }
 
-    // Re-resolve this file's outgoing call edges: the stale set is pruned in
-    // the WRITE phase (after node writes succeed), then the fresh ones below
-    // are added — so a failed node write can never leave the file edge-less.
-    files_to_prune.push(rel_path.clone());
+    // Re-resolve this file's outgoing reference edges, then decide per stored
+    // edge whether the fresh result replaces it (see the module docs): delete
+    // a stored edge only when this pass re-added the same
+    // (source, target, kind), or when its target lives inside this file —
+    // never because a cross-file reference failed to re-resolve. The
+    // deletions land in the WRITE phase (after node writes succeed), so a
+    // failed node write can never leave the file edge-less.
+    let stored = store.reference_edges_from_file(rel_path);
+    let fresh_start = edge_changes.len();
     resolve_outgoing_edges(
         base,
         cwd,
@@ -501,6 +543,22 @@ fn sync_one_file(
         next_id,
         edge_changes,
         node_tiers,
+    );
+    let added: HashSet<(u64, u64, EdgeKind)> = edge_changes[fresh_start..]
+        .iter()
+        .filter_map(|c| match c {
+            EdgeChange::Add(e) => Some((e.source_id, e.target_id, e.kind.clone())),
+            _ => None,
+        })
+        .collect();
+    edge_removals.extend(
+        stored
+            .iter()
+            .filter(|(e, target_file)| {
+                added.contains(&(e.source_id, e.target_id, e.kind.clone()))
+                    || target_file == rel_path
+            })
+            .map(|(e, _)| e.id),
     );
 }
 

--- a/crates/keel-cli/src/commands/compile_sync_tests.rs
+++ b/crates/keel-cli/src/commands/compile_sync_tests.rs
@@ -86,13 +86,266 @@ fn empty_resolvers() -> ResolverSet<'static> {
     }
 }
 
-fn incoming_of(store: &SqliteGraphStore, file: &str, name: &str) -> Vec<GraphEdge> {
-    let node = store
+fn node_id(store: &SqliteGraphStore, file: &str, name: &str) -> u64 {
+    store
         .get_nodes_in_file(file)
         .into_iter()
         .find(|n| n.name == name)
-        .expect("node exists");
-    store.get_edges(node.id, EdgeDirection::Incoming)
+        .expect("node exists")
+        .id
+}
+
+fn incoming_of(store: &SqliteGraphStore, file: &str, name: &str) -> Vec<GraphEdge> {
+    store.get_edges(node_id(store, file, name), EdgeDirection::Incoming)
+}
+
+/// The recompile fixture shared by the cross-file tests below: `src/a.rs`
+/// parsed with only its `caller` definition.
+fn caller_only_file() -> FileIndex {
+    index("src/a.rs", vec![def_at("caller", "src/a.rs", 1, 5)])
+}
+
+/// Seed `src/a.rs` (one def `caller`) and `lib/b.rs` (one def `target`) in
+/// DIFFERENT directories, plus a stored cross-file `calls` edge between them
+/// — standing in for an edge the map's whole-repo tier-2 resolver built and
+/// the compile-time ladder cannot re-resolve (no import, no shared
+/// directory, no package, no boundary).
+fn seeded_cross_file_edge(
+    store: &mut SqliteGraphStore,
+    cwd: &Path,
+    resolvers: &ResolverSet,
+    kind: EdgeKind,
+) -> (u64, u64) {
+    let files = vec![
+        caller_only_file(),
+        index("lib/b.rs", vec![def_at("target", "lib/b.rs", 1, 3)]),
+    ];
+    sync_compiled_files(store, cwd, &files, resolvers, false);
+    let caller_id = node_id(store, "src/a.rs", "caller");
+    let target_id = node_id(store, "lib/b.rs", "target");
+    let edge_id = store.max_id() + 1;
+    store
+        .update_edges(vec![EdgeChange::Add(GraphEdge {
+            id: edge_id,
+            source_id: caller_id,
+            target_id,
+            kind,
+            file_path: "src/a.rs".to_string(),
+            line: 2,
+            confidence: 0.85,
+        })])
+        .unwrap();
+    (caller_id, target_id)
+}
+
+/// The edge-erosion regression (the 10 -> 0 repro on keel's own repo): a
+/// cross-file `calls` edge the compile-time ladder cannot re-resolve must
+/// survive a compile of its source file — and keep surviving on repeated
+/// compiles (the wholesale prune deleted it on the first pass).
+#[test]
+fn unresolvable_cross_file_call_edge_survives_repeated_compiles() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    let (caller_id, _) = seeded_cross_file_edge(&mut store, &cwd, &resolvers, EdgeKind::Calls);
+
+    for _ in 0..2 {
+        let mut recompiled = caller_only_file();
+        recompiled.references = vec![call_ref("target", "src/a.rs", 2, 1)];
+        sync_compiled_files(&mut store, &cwd, &[recompiled], &resolvers, false);
+
+        let calls: Vec<_> = incoming_of(&store, "lib/b.rs", "target")
+            .into_iter()
+            .filter(|e| e.kind == EdgeKind::Calls)
+            .collect();
+        assert_eq!(
+            calls.len(),
+            1,
+            "an unresolvable cross-file call edge must survive every compile"
+        );
+        assert_eq!(calls[0].source_id, caller_id);
+    }
+}
+
+/// A cross-file call the ladder CAN re-resolve (via an import) replaces its
+/// stored edge instead of duplicating it: the replace key deliberately
+/// excludes the line, so a call site that only moved yields exactly one edge
+/// at the fresh line.
+#[test]
+fn re_resolved_cross_file_call_replaces_stale_edge_line() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    let (caller_id, _) = seeded_cross_file_edge(&mut store, &cwd, &resolvers, EdgeKind::Calls);
+
+    let mut recompiled = caller_only_file();
+    recompiled.references = vec![call_ref("target", "src/a.rs", 4, 1)];
+    recompiled.imports = vec![keel_parsers::resolver::Import {
+        source: "lib/b.rs".to_string(),
+        imported_names: vec!["target".to_string()],
+        file_path: "src/a.rs".to_string(),
+        line: 1,
+        is_relative: true,
+    }];
+    sync_compiled_files(&mut store, &cwd, &[recompiled], &resolvers, false);
+
+    let calls: Vec<_> = incoming_of(&store, "lib/b.rs", "target")
+        .into_iter()
+        .filter(|e| e.kind == EdgeKind::Calls)
+        .collect();
+    assert_eq!(
+        calls.len(),
+        1,
+        "a re-resolved call site must replace its stored edge, not duplicate it"
+    );
+    assert_eq!(calls[0].source_id, caller_id);
+    assert_eq!(calls[0].line, 4, "the fresh edge carries the moved line");
+}
+
+/// A deleted SAME-FILE call site loses its edge this compile: for a target
+/// inside the compiled file the ladder has complete information, so
+/// intra-file edges get the wholesale replace (this keeps W005 honest about
+/// same-file dead code).
+#[test]
+fn same_file_deleted_call_site_edge_is_pruned() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    let without_call = index(
+        "src/a.rs",
+        vec![
+            def_at("callee", "src/a.rs", 1, 3),
+            def_at("caller", "src/a.rs", 10, 12),
+        ],
+    );
+    let mut with_call = without_call.clone();
+    with_call.references = vec![call_ref("callee", "src/a.rs", 11, 0)];
+    sync_compiled_files(&mut store, &cwd, &[with_call], &resolvers, false);
+    assert!(
+        incoming_of(&store, "src/a.rs", "callee")
+            .iter()
+            .any(|e| e.kind == EdgeKind::Calls),
+        "seed: the same-file call edge exists"
+    );
+
+    sync_compiled_files(&mut store, &cwd, &[without_call], &resolvers, false);
+    assert!(
+        !incoming_of(&store, "src/a.rs", "callee")
+            .iter()
+            .any(|e| e.kind == EdgeKind::Calls),
+        "a deleted same-file call site must lose its edge this compile"
+    );
+}
+
+/// A deleted CROSS-FILE call site keeps its edge until the next `keel map`:
+/// compile-time resolution cannot distinguish \"call site gone\" from \"call
+/// site present but unresolvable\", so the sync never deletes on absence.
+/// Bounded staleness is the accepted trade; unbounded decay of live edges
+/// (the old wholesale prune) is not.
+#[test]
+fn cross_file_deleted_call_site_edge_lingers_until_map() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    seeded_cross_file_edge(&mut store, &cwd, &resolvers, EdgeKind::Calls);
+
+    // Recompile the caller with the call site removed entirely.
+    let recompiled = caller_only_file();
+    sync_compiled_files(&mut store, &cwd, &[recompiled], &resolvers, false);
+    assert!(
+        incoming_of(&store, "lib/b.rs", "target")
+            .iter()
+            .any(|e| e.kind == EdgeKind::Calls),
+        "a deleted cross-file call site's edge is kept until the next map"
+    );
+
+    // `keel map` remains the cleaner: clear_all drops every edge.
+    store.clear_all().unwrap();
+    assert_eq!(store.all_edges().len(), 0);
+}
+
+/// The same bounded-staleness trade applies to `uses` edges: a deleted
+/// cross-file VALUE reference keeps its edge until the next map, so W005 may
+/// under-report a dead callback between maps. This deliberately supersedes
+/// the old wholesale prune's rationale for including `uses` — see the module
+/// docs.
+#[test]
+fn cross_file_deleted_value_reference_uses_edge_lingers_until_map() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    seeded_cross_file_edge(&mut store, &cwd, &resolvers, EdgeKind::Uses);
+
+    // Recompile the caller with the value reference removed entirely.
+    let recompiled = caller_only_file();
+    sync_compiled_files(&mut store, &cwd, &[recompiled], &resolvers, false);
+    assert!(
+        incoming_of(&store, "lib/b.rs", "target")
+            .iter()
+            .any(|e| e.kind == EdgeKind::Uses),
+        "a deleted cross-file value reference's uses edge is kept until the next map"
+    );
+}
+
+/// A parse that produced zero definitions while the graph holds real nodes
+/// (an on-edit hook compiling mid-edit syntax) must leave the graph exactly
+/// as it was — the old behavior wiped the file's whole node and edge set.
+#[test]
+fn zero_definition_parse_leaves_graph_untouched() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    seeded_cross_file_edge(&mut store, &cwd, &resolvers, EdgeKind::Calls);
+    let nodes_before = store.get_nodes_in_file("src/a.rs").len();
+    let edges_before = store.all_edges().len();
+
+    let empty_parse = index("src/a.rs", vec![]);
+    sync_compiled_files(&mut store, &cwd, &[empty_parse], &resolvers, false);
+
+    assert_eq!(
+        store.get_nodes_in_file("src/a.rs").len(),
+        nodes_before,
+        "a zero-definition parse must not remove nodes"
+    );
+    assert_eq!(
+        store.all_edges().len(),
+        edges_before,
+        "a zero-definition parse must not remove edges"
+    );
+}
+
+/// The replace key includes the edge KIND: resolving a `calls` edge to a
+/// target must never delete a stored `uses` edge to the same target (and
+/// vice versa) — conflating them would let a call replace the value-usage
+/// evidence W005 relies on.
+#[test]
+fn calls_resolution_does_not_replace_uses_edge_to_same_target() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    let resolvers = empty_resolvers();
+    seeded_cross_file_edge(&mut store, &cwd, &resolvers, EdgeKind::Uses);
+
+    // Recompile with an import-resolvable CALL to the same target.
+    let mut recompiled = caller_only_file();
+    recompiled.references = vec![call_ref("target", "src/a.rs", 3, 1)];
+    recompiled.imports = vec![keel_parsers::resolver::Import {
+        source: "lib/b.rs".to_string(),
+        imported_names: vec!["target".to_string()],
+        file_path: "src/a.rs".to_string(),
+        line: 1,
+        is_relative: true,
+    }];
+    sync_compiled_files(&mut store, &cwd, &[recompiled], &resolvers, false);
+
+    let incoming = incoming_of(&store, "lib/b.rs", "target");
+    assert!(
+        incoming.iter().any(|e| e.kind == EdgeKind::Uses),
+        "the stored uses edge must survive a calls resolution to the same target"
+    );
+    assert!(
+        incoming.iter().any(|e| e.kind == EdgeKind::Calls),
+        "the fresh calls edge must land"
+    );
 }
 
 /// A same-file callback reference (`spawn(handler)`) is a usage, not a

--- a/crates/keel-core/src/sqlite.rs
+++ b/crates/keel-core/src/sqlite.rs
@@ -1,6 +1,6 @@
 use rusqlite::{params, Connection};
 
-use crate::types::GraphError;
+use crate::types::{GraphEdge, GraphError};
 
 /// Module-profile persistence, split out to keep this file well under the
 /// 800-line budget.
@@ -534,20 +534,36 @@ impl SqliteGraphStore {
         node_max.max(edge_max) as u64
     }
 
-    /// Delete every outgoing `calls` and `uses` edge originating in `file_path`.
+    /// Every stored `calls`/`uses` edge originating in `file_path`, paired
+    /// with its target node's file path.
     ///
-    /// Both kinds are stored with the referencing file's path, so this prunes a
-    /// single file's outgoing reference edges before the incremental compile
-    /// sync re-resolves them. `uses` is included because the sync re-adds it
-    /// too: leaving it behind would keep a deleted value reference alive
-    /// forever and silence W005 on a function that really did go dead.
-    /// Returns the number of rows removed.
-    pub fn prune_call_edges_from_file(&self, file_path: &str) -> Result<u64, GraphError> {
-        let deleted = self.conn.execute(
-            "DELETE FROM edges WHERE file_path = ?1 AND kind IN ('calls', 'uses')",
-            params![file_path],
-        )?;
-        Ok(deleted as u64)
+    /// The compile sync's keep/replace input (see `compile_sync`'s module
+    /// docs for the policy): the target's file is joined in because whether
+    /// the target lives inside the compiled file decides replace vs keep.
+    pub fn reference_edges_from_file(&self, file_path: &str) -> Vec<(GraphEdge, String)> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT e.*, n.file_path AS target_file
+             FROM edges e JOIN nodes n ON n.id = e.target_id
+             WHERE e.file_path = ?1 AND e.kind IN ('calls', 'uses')",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[keel] reference_edges_from_file: prepare failed: {e}");
+                return Vec::new();
+            }
+        };
+        let result = match stmt.query_map(params![file_path], |row| {
+            let edge = Self::row_to_edge(row)?;
+            let target_file: String = row.get("target_file")?;
+            Ok((edge, target_file))
+        }) {
+            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+            Err(e) => {
+                eprintln!("[keel] reference_edges_from_file: query failed: {e}");
+                Vec::new()
+            }
+        };
+        result
     }
 
     /// Clear all graph data (nodes, edges, etc.) for a full re-map.

--- a/crates/keel-core/src/sqlite_tests.rs
+++ b/crates/keel-core/src/sqlite_tests.rs
@@ -448,3 +448,50 @@ fn test_find_nodes_by_name_empty_kind_wildcard() {
     let none = store.find_nodes_by_name("nonexistent", "", "");
     assert!(none.is_empty());
 }
+
+#[test]
+fn reference_edges_from_file_scopes_by_file_and_kind() {
+    let mut store = SqliteGraphStore::in_memory().unwrap();
+    let mut caller = test_node(1, "hash_caller", "caller");
+    caller.file_path = "src/a.rs".to_string();
+    let mut target = test_node(2, "hash_target", "target");
+    target.file_path = "lib/b.rs".to_string();
+    store
+        .update_nodes(vec![NodeChange::Add(caller), NodeChange::Add(target)])
+        .unwrap();
+
+    let edge = |id: u64, source_id: u64, target_id: u64, kind: EdgeKind, file: &str| {
+        EdgeChange::Add(GraphEdge {
+            id,
+            source_id,
+            target_id,
+            kind,
+            file_path: file.to_string(),
+            line: 1,
+            confidence: 0.9,
+        })
+    };
+    store
+        .update_edges(vec![
+            edge(10, 1, 2, EdgeKind::Calls, "src/a.rs"),
+            edge(11, 1, 2, EdgeKind::Uses, "src/a.rs"),
+            edge(12, 1, 2, EdgeKind::Imports, "src/a.rs"),
+            edge(13, 2, 1, EdgeKind::Calls, "lib/b.rs"),
+        ])
+        .unwrap();
+
+    let mut result = store.reference_edges_from_file("src/a.rs");
+    result.sort_by_key(|(e, _)| e.id);
+    assert_eq!(
+        result
+            .iter()
+            .map(|(e, tf)| (e.id, e.kind.clone(), tf.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (10, EdgeKind::Calls, "lib/b.rs"),
+            (11, EdgeKind::Uses, "lib/b.rs"),
+        ],
+        "only calls/uses edges from the requested file, with the target's file joined"
+    );
+    assert!(store.reference_edges_from_file("no/such.rs").is_empty());
+}


### PR DESCRIPTION
## The bug (W009 baseline erosion root cause)

`keel compile`'s post-enforcement graph sync (`sync_compiled_files`) pruned each compiled file's outgoing `calls`/`uses` edges wholesale (`DELETE FROM edges WHERE file_path = ? AND kind IN ('calls','uses')`) and re-added what `resolve_outgoing_edges` could re-resolve. Since b9693ae the *rungs* of the resolution ladder match `keel map`'s second pass — but the *inputs* never did: map-time tier-2 resolvers have parsed the entire repo, compile-time resolvers only the compiled files. Every tier-2-resolved cross-file/cross-crate edge therefore failed to re-resolve at compile time, and one `keel compile` of a file permanently deleted them until the next full `keel map`.

**Repro on this repo (stock v0.5.0):** `keel map` → 10 cross-crate `calls` edges out of `crates/keel-cli/src/commands/compile.rs` → `keel compile` that one file → 0, none re-added. Also: fresh map → full-repo compile (quiet) → second full-repo compile fires ~6 phantom W009.

**Blast radius:** eroded edges starve W005 (live callbacks read as dead), E004's `has_live_external_callers` keep-alive (broken contracts silently dropped), E001 caller lookups, `keel discover` counts, and W009's per-directory stored-boundary baseline (`module_boundary_info`) — the phantom `new_cross_boundary_dep` warnings. With on-edit hooks compiling constantly, graphs decayed steadily between maps.

## The fix

Delete a stored reference edge only on **positive evidence**:

- **Replaced** — this pass re-added an edge with the same `(source_id, target_id, kind)`. Line is deliberately excluded from the key so a call site that merely moved replaces its row instead of duplicating it.
- **Intra-file** — the target node lives in the compiled file itself, where the ladder has complete information (local defs + same-file method resolution) and wholesale replacement is at map parity. This keeps same-file W005 honest: a deleted same-file call site loses its edge this compile.

Everything else is **kept**. A genuinely deleted cross-file call site keeps its edge until the next `keel map` (bounded staleness — the accepted trade; unbounded decay of live edges was not). This consciously supersedes the old prune doc's `uses` rationale from #50: a deleted cross-file value reference now also lingers until the map — the mirror image of the W005 false positives that wholesale-pruning live `uses` edges produced, and the cheaper error.

A parse yielding zero definitions (an on-edit hook compiling mid-edit syntax) now touches nothing — previously it wiped the file's entire node and edge set.

Mechanically: removals ride as `EdgeChange::Remove` at the **head** of the single `update_edges` transaction — adds are `INSERT OR IGNORE`, so an unchanged-line re-add processed before its removal would be ignored and then deleted. This also makes replace atomic where the old committed-DELETE-then-add could tear. `prune_call_edges_from_file` is deleted (single caller); its replacement `reference_edges_from_file` is a read-only inherent helper joining the target's file path. Frozen `GraphStore`/`LanguageResolver` traits untouched; the shared `resolve_reference` E005 seam (#54) untouched; no schema change.

## Verification

- `map → compile → recount`: cross-crate edge set **unchanged** (10 → 10 → 10; was 10 → 0).
- Fresh map → full-repo compile ×2 (473 files): **zero W009** on the second pass (was ~6 phantoms); only the known cargo-mandated `fn main` W002 pair remains.
- zenzy-atlas e2e: edge count byte-stable (16,309) across map + two compiles, identical output both runs.
- 7 new regression tests (edge survival across repeated compiles, line-shift replace-not-duplicate, intra-file prune, cross-file linger for both `calls` and `uses`, zero-def no-op, kind-preserving replace key) + a store-level test for the new helper.
- 27 test suites, `clippy -D warnings`, `fmt`, rustdoc: all clean. Design chosen by a 3-judge panel (name-based matching rejected: aliased imports record only the alias, so name matching provably deletes live edges); the diff survived an adversarial verify pass (4 findings raised, all 4 refuted with empirical repro).

**Accepted consequences** (documented in the module docs): E004 can keep firing on a caller whose call was deleted until the next map; W005 can under-report a dead cross-file callback between maps; two same-target call sites in one def collapse to one edge when only one re-resolves (multiplicity is not a contract any consumer relies on). **Pre-existing issues surfaced but out of scope:** a same-batch vanished-def + fresh-edge FK race can roll back a batch's edge sync (pre-existing, now strictly less damaging since the replace is atomic); partial parses can still swallow defs (guarded only for the zero-def case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QUcGsb5o62HRrSmAScpEx