### PR TITLE
fix(action): a clean run must not fail the step (grep -c + implicit -e)

### DIFF
--- a/.github/actions/keel/action.yml
+++ b/.github/actions/keel/action.yml
@@ -105,15 +105,24 @@ runs:
         # replaced an inline interpreter heredoc that reshaped keel's JSON — an
         # undeclared runtime dependency in a tool whose Article 1 is "single
         # binary, zero runtime dependencies". Keep this step interpreter-free.
-        keel "${cmd[@]}" --format github >"$ANNOTATIONS"
-        exit_code=$?
+        #
+        # `|| exit_code=$?`, not a bare `$?` on the next line: composite bash
+        # runs with implicit -e, so an ERROR-level keel exit would kill the
+        # script HERE — annotations unposted, outputs unset, sticky comment
+        # skipped — and the step would go red with nothing on it to read.
+        exit_code=0
+        keel "${cmd[@]}" --format github >"$ANNOTATIONS" || exit_code=$?
         echo "exit-code=$exit_code" >>"$GITHUB_OUTPUT"
 
         # The annotations ARE the output: echoing them is what posts them.
         cat "$ANNOTATIONS"
 
-        # One annotation per violation; a clean run prints nothing at all.
-        violations="$(grep -c '^::' "$ANNOTATIONS")"
+        # One annotation per violation; a clean run prints nothing at all —
+        # and `grep -c` exits 1 on that zero-match file, so without `|| true`
+        # the implicit -e turned every CLEAN run into a silent exit-1 failure
+        # (100% of pushes: `compile --changed` diffs a fresh checkout's
+        # working tree against HEAD, which is empty by construction).
+        violations="$(grep -c '^::' "$ANNOTATIONS" || true)"
         echo "violation-count=$violations" >>"$GITHUB_OUTPUT"
 
         if [ "$exit_code" -eq 0 ] && [ "$violations" -eq 0 ]; then


### PR DESCRIPTION
Root cause of keel workflow failures on every push to main in consumer repos (found via FryrAI/zenzy-rule-plane#55 section 3):

GitHub runs composite `shell: bash` steps with implicit `-e`. Two commands in the 'Run keel' step are unguarded:

1. `violations="$(grep -c '^::' "$ANNOTATIONS")"` — `grep -c` exits 1 on a zero-match (clean) file, aborting the script before `violation-count`/`summary` outputs, the step summary, and the sticky comment. On `push` events this is **100% of runs**: `compile --changed` diffs a fresh checkout's working tree against HEAD, which is empty by construction, so the annotations file is always empty. Confirmed on 4/4 push runs in zenzy-rule-plane plus one fully-clean PR run (identical silent exit-1 signature).
2. `keel "${cmd[@]}" --format github >"$ANNOTATIONS"` followed by `exit_code=$?` — a real ERROR-level keel exit kills the script before the annotations are posted; the red run carries nothing to read.

Both guarded; the step still exits with keel's real exit code, so genuine violations stay red — now with their annotations actually posted.

**Flagged, deliberately not changed here:** push-mode `compile --changed` remains vacuous in CI (0 files, always clean) for the same working-tree-vs-HEAD reason. Scoping push compiles to the pushed range (e.g. `--since`) is a behavior change on the floating `v0` tag and deserves its own reviewed change.

After merge: `v0` needs to be re-pointed at the merge commit so consumer repos pick the fix up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CioGToWvKEYFE7tSkcLDZa